### PR TITLE
It would be great that we could execute only one level 

### DIFF
--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -416,8 +416,7 @@ def tests_from_suite(suite, options, dlevel=1,
     elif isinstance(suite, StartUpFailure):
         yield (suite, None)
     else:
-        import pdb; pdb.set_trace()
-        if options.only and level == options.level:
+        if options.only and level == options.only:
             accept = build_filtering_func(options.test)
             if accept(str(suite)):
                 yield (suite, layer)

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -416,10 +416,11 @@ def tests_from_suite(suite, options, dlevel=1,
     elif isinstance(suite, StartUpFailure):
         yield (suite, None)
     else:
-        if options.only and level == options.only:
+        if options.only:
             accept = build_filtering_func(options.test)
-            if accept(str(suite)):
+            if accept(str(suite)) and level == options.only:
                 yield (suite, layer)
+
         elif level <= options.at_level:
             accept = build_filtering_func(options.test)
             if accept(str(suite)):

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -416,7 +416,12 @@ def tests_from_suite(suite, options, dlevel=1,
     elif isinstance(suite, StartUpFailure):
         yield (suite, None)
     else:
-        if level <= options.at_level:
+        import pdb; pdb.set_trace()
+        if options.only and level == options.level:
+            accept = build_filtering_func(options.test)
+            if accept(str(suite)):
+                yield (suite, layer)
+        elif level <= options.at_level:
             accept = build_filtering_func(options.test)
             if accept(str(suite)):
                 yield (suite, layer)

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -127,6 +127,10 @@ searching.add_option(
     help="Run tests at all levels.")
 
 searching.add_option(
+    '-y', '--only', type="int", dest='only',
+    help="Run only tests at the selected level")
+
+searching.add_option(
     '--list-tests', action="store_true", dest='list_tests',
     help="List all tests that matched your filters.  Do not run any tests.")
 


### PR DESCRIPTION
On Plone test infraestructure we have the robot tests on different level from the normal tests and we would like to configure jenkins to execute only robot tests on a job.

Now we are using -t robot but its a bit hacky.
