### PR TITLE
Fix issue with mro in zodb

### DIFF
--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -886,11 +886,15 @@ def order_by_bases(layers):
     """Order the layers from least to most specific (bottom to top)
        Group layers with common bases and put unittests first.
     """
-    getmro = inspect.getmro
+    def getmro(layer):
+        try:
+            return inspect.getmro(layer)
+        except AttributeError:
+            return inspect.getmro(layer.__class__)
 
     def layer_sortkey(layer):
         return tuple((c.__module__, c.__name__) for c in getmro(layer)[::-1]
-                      if c not in (object, UnitTests))
+                     if c not in (object, UnitTests))
 
     layers = sorted(layers, key=layer_sortkey, reverse=True)
     gathered = []


### PR DESCRIPTION
@mgedmin Thanks for point me to the failing zodb tests.
I am not happy with this solution, but checking for the __mro__ attribute failed, probably because of the python trick to make __ private, and isinstance(layer, type) also failed, maybe because of old style layer classes.
I was also wondering, if it is legal to have an object as a layer, but the docs don't say.
I manually tests zodb with 3.4 and this change, and my tests then ran through