### PR TITLE
Fix instance based layers

### DIFF
--- a/src/zope/testrunner/interfaces.py
+++ b/src/zope/testrunner/interfaces.py
@@ -100,3 +100,60 @@ class ITestRunner(zope.interface.Interface):
 
     options = zope.interface.Attribute(
       "Provides access to configuration options.")
+
+
+class IMinimalTestLayer(zope.interface.Interface):
+    """A test layer.
+
+    This is the bare minimum that a ``layer`` attribute on a test suite
+    should provide.
+    """
+
+    __bases__ = zope.interface.Attribute(
+        "A tuple of base layers.")
+
+    __name__ = zope.interface.Attribute(
+        "Name of the layer")
+
+    __module__ = zope.interface.Attribute(
+        "Dotted name of the module that defines this layer")
+
+    def __hash__():
+        """A test layer must be hashable"""
+
+
+class IFullTestLayer(IMinimalTestLayer):
+    """A test layer.
+
+    This is the full list of optional methods that a test layer can specify.
+    """
+
+    def setUp():
+        """Shared layer setup.
+
+        Called once before any of the tests in this layer (or sublayers)
+        are run.
+        """
+
+    def tearDown():
+        """Shared layer teardown.
+
+        Called once after all the tests in this layer (and sublayers)
+        are run.
+
+        May raise NotImplementedError.
+        """
+
+    def testSetUp():
+        """Additional test setup.
+
+        Called once before every of test in this layer (or sublayers)
+        is run.
+        """
+
+    def testTearDown():
+        """Additional test teardown.
+
+        Called once after every of test in this layer (or sublayers)
+        is run.
+        """

--- a/src/zope/testrunner/interfaces.py
+++ b/src/zope/testrunner/interfaces.py
@@ -119,7 +119,18 @@ class IMinimalTestLayer(zope.interface.Interface):
         "Dotted name of the module that defines this layer")
 
     def __hash__():
-        """A test layer must be hashable"""
+        """A test layer must be hashable.
+
+        The default identity-based __eq__ and __hash__ that Python provides
+        usually suffice.
+        """
+
+    def __eq__():
+        """A test layer must be hashable.
+
+        The default identity-based __eq__ and __hash__ that Python provides
+        usually suffice.
+        """
 
 
 class IFullTestLayer(IMinimalTestLayer):

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -423,7 +423,7 @@ class SetUpLayerFailure(unittest.TestCase):
         pass
 
     def __str__(self):
-        return "Layer: %s.%s" % (self.layer.__module__, self.layer.__name__)
+        return "Layer: %s" % (name_from_layer(self.layer))
 
 
 

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -205,6 +205,7 @@ def test_suite():
         'testrunner-edge-cases.txt',
         'testrunner-errors.txt',
         'testrunner-layers-api.txt',
+        'testrunner-layers-instances.txt',
         'testrunner-layers-buff.txt',
         'testrunner-layers-cantfind.txt',
         'testrunner-layers-cwd.txt',

--- a/src/zope/testrunner/tests/test_runner.py
+++ b/src/zope/testrunner/tests/test_runner.py
@@ -1,0 +1,173 @@
+##############################################################################
+#
+# Copyright (c) 2015 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Unit tests for the testrunner's runner logic
+"""
+
+import unittest
+
+from zope.testrunner import runner
+from zope.testrunner.layer import UnitTests
+
+
+class TestLayerOrdering(unittest.TestCase):
+
+    def sort_key(self, layer):
+        return ', '.join(qn.rpartition('.')[-1]
+                         for qn in runner.layer_sort_key(layer))
+
+    def order(self, *layers):
+        return ', '.join(l.__name__ for l in runner.order_by_bases(layers))
+
+    def test_order_by_bases(self):
+        #    A      B
+        #   /|\    /
+        #  / | \  /
+        # A1 A2 AB
+        class A(object): pass
+        class A1(A): pass
+        class A2(A): pass
+        class B(object): pass
+        class AB(A, B): pass
+        self.assertEqual(self.order(B, A1, A2, A1, AB, UnitTests),
+                         'UnitTests, A1, A2, B, AB')
+        self.assertEqual(self.sort_key(UnitTests), '')
+        self.assertEqual(self.sort_key(A1), 'A, A1')
+        self.assertEqual(self.sort_key(A2), 'A, A2')
+        self.assertEqual(self.sort_key(B), 'B')
+        self.assertEqual(self.sort_key(AB), 'B, A, AB')
+
+    def test_order_by_bases_alphabetical_order(self):
+        class X(object): pass
+        class Y(object): pass
+        class Z(object): pass
+        class A(Y): pass
+        class B(X): pass
+        class C(Z): pass
+        # It'd be nice to get A, B, C here, but that's not trivial.
+        self.assertEqual(self.order(A, B, C), 'B, A, C')
+        self.assertEqual(self.sort_key(B), 'X, B')
+        self.assertEqual(self.sort_key(A), 'Y, A')
+        self.assertEqual(self.sort_key(C), 'Z, C')
+
+    def test_order_by_bases_diamond_hierarchy(self):
+        #      A
+        #     / \
+        #    B   D
+        #    |   |
+        #    C   E
+        #     \ /
+        #      F
+        class A(object): pass
+        class B(A): pass
+        class C(B): pass
+        class D(A): pass
+        class E(D): pass
+        class F(C, E): pass
+        self.assertEqual(self.order(A, B, C, D, E, F), 'A, B, C, D, E, F')
+        self.assertEqual(self.sort_key(A), 'A')
+        self.assertEqual(self.sort_key(B), 'A, B')
+        self.assertEqual(self.sort_key(C), 'A, B, C')
+        self.assertEqual(self.sort_key(D), 'A, D')
+        self.assertEqual(self.sort_key(E), 'A, D, E')
+        self.assertEqual(self.sort_key(F), 'A, D, E, B, C, F')
+        # only those layers that were passed in are returned
+        self.assertEqual(self.order(B, E), 'B, E')
+
+    def test_order_by_bases_shared_setup_trumps_alphabetical_order(self):
+        #       A
+        #      / \
+        #     AB AC
+        #    /  \  \
+        # AAAABD \ MMMACF
+        #      ZZZABE
+        class A(object): pass
+        class AB(A): pass
+        class AC(A): pass
+        class AAAABD(AB): pass
+        class ZZZABE(AB): pass
+        class MMMACF(AC): pass
+        self.assertEqual(self.order(AAAABD, MMMACF, ZZZABE),
+                         'AAAABD, ZZZABE, MMMACF')
+        self.assertEqual(self.sort_key(AAAABD), 'A, AB, AAAABD')
+        self.assertEqual(self.sort_key(ZZZABE), 'A, AB, ZZZABE')
+        self.assertEqual(self.sort_key(MMMACF), 'A, AC, MMMACF')
+
+    def test_order_by_bases_multiple_inheritance(self):
+        # Layerx      Layer1
+        # |  \        /    \
+        # |   \ Layer11    Layer12
+        # |    \   | |      /    \
+        # | Layer111 | Layer121  Layer122
+        #  \        /
+        #   \      /
+        #   Layer112
+        #
+        class Layer1: pass
+        class Layerx: pass
+        class Layer11(Layer1): pass
+        class Layer12(Layer1): pass
+        class Layer111(Layerx, Layer11): pass
+        class Layer121(Layer12): pass
+        class Layer112(Layerx, Layer11): pass
+        class Layer122(Layer12): pass
+        self.assertEqual(
+            self.order(Layer1, Layer11, Layer12, Layer111, Layer112, Layer121,
+                       Layer122),
+            'Layer1, Layer11, Layer111, Layer112, Layer12, Layer121, Layer122')
+        self.assertEqual(self.order(Layer111, Layer12), 'Layer111, Layer12')
+        self.assertEqual(self.order(Layerx, Layer1, Layer11, Layer112),
+                         'Layer1, Layer11, Layerx, Layer112')
+        self.assertEqual(self.sort_key(Layer111),
+                         'Layer1, Layer11, Layerx, Layer111')
+        self.assertEqual(self.sort_key(Layer12),
+                         'Layer1, Layer12')
+
+    def test_order_by_bases_reverse_tree(self):
+        # E   D  F
+        #  \ / \ /
+        #   B   C
+        #    \ /
+        #     A
+        class F(object): pass
+        class E(object): pass
+        class D(object): pass
+        class C(D, F): pass
+        class B(D, E): pass
+        class A(B, C): pass
+        self.assertEqual(self.order(A, B, C), 'B, C, A')
+        self.assertEqual(self.order(A, B, C, D, E, F), 'D, E, B, F, C, A')
+
+    def test_order_by_bases_mro_is_complicated(self):
+        #  A  C  B  E  D
+        # / \ | / \ | / \
+        # \  K1     K2  /
+        #  `---.    _--'
+        #     \ \  / |
+        #      \ K3 /
+        #       \ |/
+        #        ZZ
+        class A(object): pass
+        class B(object): pass
+        class C(object): pass
+        class D(object): pass
+        class E(object): pass
+        class K1(A, B, C): pass
+        class K2(D, B, E): pass
+        class K3(D, A): pass
+        class ZZ(K1, K2, K3): pass
+        self.assertEqual(self.order(K1, K2, K3, ZZ),
+                         'K3, K2, K1, ZZ')
+        # Sorting by reverse MRO, as computed by Python's MRO algorithm,
+        # would put the layers in a different order: K3, K1, K2, ZZ.
+        # Does that matter?  The class diagram is symmetric, so I think not.

--- a/src/zope/testrunner/tests/testrunner-layers-instances.txt
+++ b/src/zope/testrunner/tests/testrunner-layers-instances.txt
@@ -1,0 +1,183 @@
+Layers implemented via object instances
+=======================================
+
+Layers are generally implemented as classes using class methods, but
+regular objects can be used as well.  They need to provide __module__,
+__name__, and __bases__ attributes.
+
+>>> class TestLayer:
+...     def __init__(self, name, *bases):
+...         self.__name__ = name
+...         self.__bases__ = bases
+...
+...     def setUp(self):
+...         log('%s.setUp' % self.__name__)
+...
+...     def tearDown(self):
+...         log('%s.tearDown' % self.__name__)
+...
+...     def testSetUp(self):
+...         log('%s.testSetUp' % self.__name__)
+...
+...     def testTearDown(self):
+...         log('%s.testTearDown' % self.__name__)
+
+>>> BaseLayer = TestLayer('BaseLayer')
+>>> TopLayer = TestLayer('TopLayer', BaseLayer)
+
+Tests or test suites specify what layer they need by storing a reference
+in the 'layer' attribute.
+
+>>> import unittest
+>>> class TestSpecifyingBaseLayer(unittest.TestCase):
+...     'This TestCase explicitly specifies its layer'
+...     layer = BaseLayer
+...     name = 'TestSpecifyingBaseLayer' # For testing only
+...
+...     def setUp(self):
+...         log('TestSpecifyingBaseLayer.setUp')
+...
+...     def tearDown(self):
+...         log('TestSpecifyingBaseLayer.tearDown')
+...
+...     def test1(self):
+...         log('TestSpecifyingBaseLayer.test1')
+...
+...     def test2(self):
+...         log('TestSpecifyingBaseLayer.test2')
+...
+>>> class TestSpecifyingNoLayer(unittest.TestCase):
+...     'This TestCase specifies no layer'
+...     name = 'TestSpecifyingNoLayer' # For testing only
+...     def setUp(self):
+...         log('TestSpecifyingNoLayer.setUp')
+...
+...     def tearDown(self):
+...         log('TestSpecifyingNoLayer.tearDown')
+...
+...     def test1(self):
+...         log('TestSpecifyingNoLayer.test')
+...
+...     def test2(self):
+...         log('TestSpecifyingNoLayer.test')
+...
+
+Create a TestSuite containing two test suites, one for each of
+TestSpecifyingBaseLayer and TestSpecifyingNoLayer.
+
+>>> umbrella_suite = unittest.TestSuite()
+>>> umbrella_suite.addTest(unittest.makeSuite(TestSpecifyingBaseLayer))
+>>> no_layer_suite = unittest.makeSuite(TestSpecifyingNoLayer)
+>>> umbrella_suite.addTest(no_layer_suite)
+
+Before we can run the tests, we need to setup some helpers.
+
+>>> from zope.testrunner import options
+>>> from zope.testing.loggingsupport import InstalledHandler
+>>> import logging
+>>> log_handler = InstalledHandler('zope.testrunner.tests')
+>>> def log(msg):
+...     logging.getLogger('zope.testrunner.tests').info(msg)
+>>> def fresh_options():
+...     opts = options.get_options(['--test-filter', '.*'])
+...     opts.resume_layer = None
+...     opts.resume_number = 0
+...     return opts
+
+Now we run the tests. Note that the BaseLayer was not setup when
+the TestSpecifyingNoLayer was run and setup/torn down around the
+TestSpecifyingBaseLayer tests.
+
+>>> from zope.testrunner.runner import Runner
+>>> runner = Runner(options=fresh_options(), args=[], found_suites=[umbrella_suite])
+>>> succeeded = runner.run()
+Running zope.testrunner.layer.UnitTests tests:
+  Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+  Ran 2 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+Running ...BaseLayer tests:
+  Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+  Set up ...BaseLayer in N.NNN seconds.
+  Ran 2 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+Tearing down left over layers:
+  Tear down ...BaseLayer in N.NNN seconds.
+Total: 4 tests, 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+
+
+Now lets specify a layer in the suite containing TestSpecifyingNoLayer
+and run the tests again. This demonstrates the other method of specifying
+a layer. This is generally how you specify what layer doctests need.
+
+>>> no_layer_suite.layer = BaseLayer
+>>> runner = Runner(options=fresh_options(), args=[], found_suites=[umbrella_suite])
+>>> succeeded = runner.run()
+Running ...BaseLayer tests:
+  Set up ...BaseLayer in N.NNN seconds.
+  Ran 4 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+Tearing down left over layers:
+  Tear down ...BaseLayer in N.NNN seconds.
+
+Clear our logged output, as we want to inspect it shortly.
+
+>>> log_handler.clear()
+
+Now lets also specify a layer in the TestSpecifyingNoLayer class and rerun
+the tests. This demonstrates that the most specific layer is used. It also
+shows the behavior of nested layers - because TopLayer extends BaseLayer,
+both the BaseLayer and TopLayer environments are setup when the
+TestSpecifyingNoLayer tests are run.
+
+>>> TestSpecifyingNoLayer.layer = TopLayer
+>>> runner = Runner(options=fresh_options(), args=[], found_suites=[umbrella_suite])
+>>> succeeded = runner.run()
+Running ...BaseLayer tests:
+  Set up ...BaseLayer in N.NNN seconds.
+  Ran 2 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+Running ...TopLayer tests:
+  Set up ...TopLayer in N.NNN seconds.
+  Ran 2 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+Tearing down left over layers:
+  Tear down ...TopLayer in N.NNN seconds.
+  Tear down ...BaseLayer in N.NNN seconds.
+Total: 4 tests, 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+
+
+If we inspect our trace of what methods got called in what order, we can
+see that the layer setup and teardown methods only got called once. We can
+also see that the layer's test setup and teardown methods got called for
+each test using that layer in the right order.
+
+>>> def report():
+...     print("Report:")
+...     for record in log_handler.records:
+...         print(record.getMessage())
+>>> report()
+Report:
+BaseLayer.setUp
+BaseLayer.testSetUp
+TestSpecifyingBaseLayer.setUp
+TestSpecifyingBaseLayer.test1
+TestSpecifyingBaseLayer.tearDown
+BaseLayer.testTearDown
+BaseLayer.testSetUp
+TestSpecifyingBaseLayer.setUp
+TestSpecifyingBaseLayer.test2
+TestSpecifyingBaseLayer.tearDown
+BaseLayer.testTearDown
+TopLayer.setUp
+BaseLayer.testSetUp
+TopLayer.testSetUp
+TestSpecifyingNoLayer.setUp
+TestSpecifyingNoLayer.test
+TestSpecifyingNoLayer.tearDown
+TopLayer.testTearDown
+BaseLayer.testTearDown
+BaseLayer.testSetUp
+TopLayer.testSetUp
+TestSpecifyingNoLayer.setUp
+TestSpecifyingNoLayer.test
+TestSpecifyingNoLayer.tearDown
+TopLayer.testTearDown
+BaseLayer.testTearDown
+TopLayer.tearDown
+BaseLayer.tearDown
+


### PR DESCRIPTION
Commit 3a68ee9c41f4da4f6f64a1fb3fa2801a9a8e322b improved layer sorting but accidentally dropped support for instance-based layers.  These turn out to be rather widely used (in ZODB, in zope.app.testing, in plone.testing etc).

This change fixes the above problem in a different way from PR #6: it replacing inspect.getmro(layer) with a recursive sort key computation that traverses layer.\__bases__.

It doesn't actually use the C3 algorithm for MRO computation.  I tried to find an example where that would matter and couldn't.

This change also adds tests to prevent this from regressing in the future and defines the test runner's expectations for test layers as interfaces.