### PR TITLE
Update python-subunit to 1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ python:
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/setup.py
+++ b/setup.py
@@ -30,17 +30,14 @@ if sys.version_info < (2,6) or sys.version_info[:2] == (3,0):
 
 
 
-if sys.version_info >= (3,):
-    tests_require = ['zope.testing']
-    extra = dict(# XXX:  python-subunit is not yet ported to Python3.
-                 extras_require = {'test': ['zope.testing']},
-                 )
+tests_require = ['zope.testing']
+if sys.version_info[0:2] == (2, 6):
+    tests_require.append('unittest2')
+    tests_require.append('python-subunit < 1.0dev')
 else:
-    tests_require = ['zope.testing', 'python-subunit']
-    if sys.version_info[0:2] == (2, 6):
-        tests_require.append('unittest2')
-    extra = dict(tests_require = tests_require,
-                 extras_require = {'test': tests_require})
+    tests_require.append('python-subunit')
+extra = dict(tests_require = tests_require,
+                extras_require = {'test': tests_require})
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,21 +8,12 @@ envlist =
 [testenv]
 deps =
     zope.testing
+    python-subunit
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
 [testenv:py26]
 deps =
-    {[testenv]deps}
-    python-subunit
+    zope.testing
+    python-subunit<1.0dev
     unittest2
-
-[testenv:py27]
-deps =
-    {[testenv]deps}
-    python-subunit
-
-[testenv:pypy]
-deps =
-    {[testenv]deps}
-    python-subunit


### PR DESCRIPTION
Except, pin to '<1.0dev' for Python 2.6.

Note that tests fail on Py3k:  I'm pushing this as a PR to ask for
help from @rbtcollins
