### PR TITLE
Support skipped tests in subunit output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ zope.testrunner Changelog
 4.4.8 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Support skipped tests in subunit output
 
 
 4.4.7 (2015-04-02)

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -959,6 +959,9 @@ class SubunitOutputFormatter(object):
         self._emit_timestamp()
         self._subunit.addSuccess(test)
 
+    def test_skipped(self, test, reason):
+        self._subunit.addSkip(test, reason)
+
     def import_errors(self, import_errors):
         """Report test-module import errors (if any)."""
         if not import_errors:

--- a/src/zope/testrunner/tests/testrunner-subunit.txt
+++ b/src/zope/testrunner/tests/testrunner-subunit.txt
@@ -675,6 +675,39 @@ Note that debugging doesn't work when running tests in a subprocess:
     ]
     True
 
+
+Support skipped tests
+---------------------
+
+    >>> directory_with_skipped_tests = os.path.join(this_directory,
+    ...                                             'testrunner-ex-skip')
+    >>> skip_defaults = [
+    ...     '--path', directory_with_skipped_tests,
+    ...     '--tests-pattern', '^sample_skipped_tests$',
+    ...  ]
+    >>> sys.argv = ['test']
+    >>> testrunner.run_internal(
+    ...     skip_defaults + ["--subunit", "-t", "TestSkipppedNoLayer"])
+    time: ...
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: ...
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    time: ...
+    test: sample_skipped_tests.TestSkipppedNoLayer.test_skipped
+    skip: sample_skipped_tests.TestSkipppedNoLayer.test_skipped [
+    I'm a skipped test!
+    ]
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: ...
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: ...
+    successful: zope.testrunner.layer.UnitTests:tearDown
+    False
+
+
 And remove the temporary directory:
 
     >>> shutil.rmtree(tmpdir)


### PR DESCRIPTION
Previously, attempting to run test suite, containing skipped tests with
``--subunit`` option produced exception:

    AttributeError: 'SubunitOutputFormatter' object has no attribute 'test_skipped'
