### PR TITLE
More efficient test filtering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ zope.testrunner Changelog
 ==================
 
 - Support skipped tests in subunit output
+- More efficient test filtering
 
 
 4.4.7 (2015-04-02)


### PR DESCRIPTION
On projects with large number of tests, ``zope.testrunner`` test filtering feature performed very poorly, especially with lots of filtering options.

For example, in a project, containing about 3000 tests, it took about 1:11 minutes to collect (not execute) tests, specified in 170 ``-t`` options on command line. Time grows linearly with number of ``-t`` options.

This patch removes this inefficiency (and brings collection time down to about 3s).