### PR TITLE
Stop running of tests of all layers when using -x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ zope.testrunner Changelog
 4.5.0 (unreleased)
 ==================
 
+- Stop tests for all layers when test fails/errors when started with
+  -x/--stop-on-error
+
 - Drop support for Python 2.6 and 3.2.
 
 

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -264,6 +264,9 @@ class Runner(object):
                 should_resume = True
                 break
 
+            if self.options.stop_on_error and (self.failures or self.errors):
+                break
+
         if should_resume:
             if layers_to_run:
                 self.ran += resume_tests(

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -223,6 +223,7 @@ def test_suite():
         'testrunner-knit.txt',
         'testrunner-shuffle.txt',
         'testrunner-eggsupport.txt',
+        'testrunner-stops-when-stop-on-error.txt',
         setUp=setUp, tearDown=tearDown,
         optionflags=doctest.ELLIPSIS+doctest.NORMALIZE_WHITESPACE,
         checker=checker),

--- a/src/zope/testrunner/tests/testrunner-ex-37/layers.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/layers.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2013 Zope Foundation and Contributors.
+# Copyright (c) 2016 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,

--- a/src/zope/testrunner/tests/testrunner-ex-37/layers.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/layers.py
@@ -1,0 +1,21 @@
+##############################################################################
+#
+# Copyright (c) 2013 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+
+class LayerA:
+    pass
+
+
+class LayerB:
+    pass

--- a/src/zope/testrunner/tests/testrunner-ex-37/stop_on_error.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/stop_on_error.py
@@ -1,0 +1,29 @@
+##############################################################################
+#
+# Copyright (c) 2013 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+
+
+class ErrorTestCase1(unittest.TestCase):
+    layer = "layers.LayerA"
+
+    def test(self):
+        self.assertTrue(False)
+
+
+class ErrorTestCase2(unittest.TestCase):
+    layer = "layers.LayerB"
+
+    def test(self):
+        self.assertTrue(False)

--- a/src/zope/testrunner/tests/testrunner-ex-37/stop_on_error.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/stop_on_error.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2013 Zope Foundation and Contributors.
+# Copyright (c) 2016 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,

--- a/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2013 Zope Foundation and Contributors.
+# Copyright (c) 2016 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,

--- a/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
@@ -1,0 +1,31 @@
+##############################################################################
+#
+# Copyright (c) 2013 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+import unittest
+
+
+class FailureTestCase1(unittest.TestCase):
+    layer = "layers.LayerA"
+
+    def test(self):
+        # We want to have an error, not a failure
+        raise StandardError
+
+
+class FailureTestCase2(unittest.TestCase):
+    layer = "layers.LayerB"
+
+    def test(self):
+        # We want to have an error, not a failure
+        raise StandardError

--- a/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
+++ b/src/zope/testrunner/tests/testrunner-ex-37/stop_on_failure.py
@@ -20,7 +20,7 @@ class FailureTestCase1(unittest.TestCase):
 
     def test(self):
         # We want to have an error, not a failure
-        raise StandardError
+        raise Exception
 
 
 class FailureTestCase2(unittest.TestCase):
@@ -28,4 +28,4 @@ class FailureTestCase2(unittest.TestCase):
 
     def test(self):
         # We want to have an error, not a failure
-        raise StandardError
+        raise Exception

--- a/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.txt
+++ b/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.txt
@@ -70,8 +70,8 @@ Same for failures, without the flag, we see two layers
     Error in test test (stop_on_failure.FailureTestCase1)
     Traceback (most recent call last):
      testrunner-ex-37/stop_on_failure.py", Line NNN, in test
-        raise StandardError
-    StandardError
+        raise Exception
+    Exception
       Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
     Running layers.LayerB tests:
       Tear down layers.LayerA in N.NNN seconds.
@@ -79,8 +79,8 @@ Same for failures, without the flag, we see two layers
     Error in test test (stop_on_failure.FailureTestCase2)
     Traceback (most recent call last):
      testrunner-ex-37/stop_on_failure.py", Line NNN, in test
-        raise StandardError
-    StandardError
+        raise Exception
+    Exception
       Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down layers.LayerB in N.NNN seconds.
@@ -96,8 +96,8 @@ When we do pass the flag we see only one layer is tested
     Error in test test (stop_on_failure.FailureTestCase1)
     Traceback (most recent call last):
      testrunner-ex-37/stop_on_failure.py", Line NNN, in test
-        raise StandardError
-    StandardError
+        raise Exception
+    Exception
       Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down layers.LayerA in N.NNN seconds.

--- a/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.txt
+++ b/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.txt
@@ -1,0 +1,104 @@
+testrunner stops test run when --stop-on-error is used and there's an error
+===========================================================================
+Issue/bug #37 on Github: the test runner stops running tests *for the current
+layer only* when started with -x/--stop-on-error and a test fails. We want the
+test runner to stop running all tests.
+
+::
+
+    >>> import os, sys
+    >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex-37')
+    >>> from zope import testrunner
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^stop_on_error',
+    ...  ]
+    >>> sys.argv = ['test']
+
+When we don't pass the flag, we see two layers are tested
+---------------------------------------------------------
+
+    >>> testrunner.run_internal(defaults)
+    Running layers.LayerA tests:
+      Set up layers.LayerA in N.NNN seconds.
+    Failure in test test (stop_on_error.ErrorTestCase1)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_error.py", Line NNN, in test
+        self.assertTrue(False)
+    AssertionError: False is not true
+      Ran 1 tests with 1 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Running layers.LayerB tests:
+      Tear down layers.LayerA in N.NNN seconds.
+      Set up layers.LayerB in N.NNN seconds.
+    Failure in test test (stop_on_error.ErrorTestCase2)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_error.py", Line NNN, in test
+        self.assertTrue(False)
+    AssertionError: False is not true
+      Ran 1 tests with 2 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down layers.LayerB in N.NNN seconds.
+    Total: 2 tests, 2 failures, 0 errors and 0 skipped in N.NNN seconds.
+    True
+
+When we do pass the flag we see only one layer is tested
+--------------------------------------------------------
+
+    >>> testrunner.run_internal(defaults + ["--stop-on-error"])
+    Running layers.LayerA tests:
+      Set up layers.LayerA in N.NNN seconds.
+    Failure in test test (stop_on_error.ErrorTestCase1)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_error.py", Line NNN, in test
+        self.assertTrue(False)
+    AssertionError: False is not true
+      Ran 1 tests with 1 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down layers.LayerA in N.NNN seconds.
+    True
+
+Same for failures, without the flag, we see two layers
+------------------------------------------------------
+
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^stop_on_failure',
+    ...  ]
+    >>> testrunner.run_internal(defaults)
+    Running layers.LayerA tests:
+      Set up layers.LayerA in N.NNN seconds.
+    Error in test test (stop_on_failure.FailureTestCase1)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_failure.py", Line NNN, in test
+        raise StandardError
+    StandardError
+      Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
+    Running layers.LayerB tests:
+      Tear down layers.LayerA in N.NNN seconds.
+      Set up layers.LayerB in N.NNN seconds.
+    Error in test test (stop_on_failure.FailureTestCase2)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_failure.py", Line NNN, in test
+        raise StandardError
+    StandardError
+      Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down layers.LayerB in N.NNN seconds.
+    Total: 2 tests, 0 failures, 2 errors and 0 skipped in N.NNN seconds.
+    True
+
+When we do pass the flag we see only one layer is tested
+--------------------------------------------------------
+
+    >>> testrunner.run_internal(defaults + ["--stop-on-error"])
+    Running layers.LayerA tests:
+      Set up layers.LayerA in N.NNN seconds.
+    Error in test test (stop_on_failure.FailureTestCase1)
+    Traceback (most recent call last):
+     testrunner-ex-37/stop_on_failure.py", Line NNN, in test
+        raise StandardError
+    StandardError
+      Ran 1 tests with 0 failures, 1 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down layers.LayerA in N.NNN seconds.
+    True


### PR DESCRIPTION
Bug #37: 

Previously the -x/--stop-on-error flag stopped running of tests on one layer
only.