### PR TITLE
Drop conditional 'unittest2' dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ zope.testrunner Changelog
   (because the testrunner replaced ``sys.stdin`` with an unclosable
   object).
 
+- Drop conditional dependency on ``unittest2`` (redundant after dropping
+  support for Python 2.6).
+
 
 4.5.0 (2016-05-02)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,6 @@ if sys.version_info >= (3,):
                  )
 else:
     tests_require = ['zope.testing', 'python-subunit']
-    if sys.version_info[0:2] == (2, 6):
-        tests_require.append('unittest2')
     extra = dict(tests_require = tests_require,
                  extras_require = {'test': tests_require})
 

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -15,20 +15,15 @@
 """
 from __future__ import print_function
 
-import collections
 import subprocess
 import errno
 import gc
-import inspect
 import re
 import sys
 import threading
 import time
 import traceback
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from six import StringIO
 from zope.testrunner.find import import_name
@@ -353,9 +348,6 @@ def run_tests(options, tests, name, failures, errors, skipped, import_errors):
             # Python versions prior to 2.7 do not have the concept of
             # unexpectedSuccesses.
             failures.extend(result.unexpectedSuccesses)
-        if not hasattr(result, 'skipped'):
-            # Only in Python >= 2.7, Python >= 3.1, and when using unittest2
-            result.skipped = []
         skipped.extend(result.skipped)
         errors.extend(result.errors)
         output.summary(n_tests=result.testsRun,

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -299,21 +299,13 @@ def test_suite():
                     )
                 )
 
-    skip_feature = True
-    if sys.version_info < (2, 7, 0):
-        try:
-            import unittest2
-        except ImportError:
-            skip_feature = False
-
-    if skip_feature:
-        suites.append(
-            doctest.DocFileSuite(
-                'testrunner-report-skipped.txt',
-                setUp=setUp, tearDown=tearDown,
-                optionflags=doctest.ELLIPSIS+doctest.NORMALIZE_WHITESPACE,
-                checker=checker)
-        )
+    suites.append(
+        doctest.DocFileSuite(
+            'testrunner-report-skipped.txt',
+            setUp=setUp, tearDown=tearDown,
+            optionflags=doctest.ELLIPSIS+doctest.NORMALIZE_WHITESPACE,
+            checker=checker)
+    )
 
     if hasattr(sys, 'gettotalrefcount'):
         suites.append(

--- a/src/zope/testrunner/tests/testrunner-ex-skip/sample_skipped_tests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-skip/sample_skipped_tests.py
@@ -12,10 +12,7 @@
 #
 ##############################################################################
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestSkipppedWithLayer(unittest.TestCase):


### PR DESCRIPTION
Redundant after dropping support for Python 2.6.

Closes #22.