### PR TITLE
Fixed: Using the -j option to run tests in multiple processes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ zope.testrunner Changelog
 4.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed: Using the ``-j`` option to run tests in multiple processes
+  caused tests that used the ``multiprocessing`` package to hang
+  (because the testrunner replaced ``sys.stdin`` with an unclosable
+  object).
 
 
 4.5.0 (2016-05-02)

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -959,3 +959,6 @@ class FakeInputContinueGenerator:
         print('*'*70)
         print()
         return 'c\n'
+
+    def close(self):
+        pass

--- a/src/zope/testrunner/tests/test_runner.py
+++ b/src/zope/testrunner/tests/test_runner.py
@@ -171,3 +171,12 @@ class TestLayerOrdering(unittest.TestCase):
         # Sorting by reverse MRO, as computed by Python's MRO algorithm,
         # would put the layers in a different order: K3, K1, K2, ZZ.
         # Does that matter?  The class diagram is symmetric, so I think not.
+
+    def test_FakeInputContinueGenerator_close(self):
+        # multiprocessing (and likely other forkful frameworks want to
+        # close sys.stdin.  The test runner replaces sys.stdin with a
+        # FakeInputContinueGenerator for some reason. It should be
+        # closeable.
+
+        f = runner.FakeInputContinueGenerator()
+        f.close()

--- a/src/zope/testrunner/tests/testrunner-errors.txt
+++ b/src/zope/testrunner/tests/testrunner-errors.txt
@@ -724,7 +724,7 @@ Then run the tests:
     >>> sys.argv = ('test --tests-pattern ^sampletests(f|_i)?$ --layer 1 '
     ...            ).split()
     >>> testrunner.run_internal(defaults)
-    ... # doctest: +NORMALIZE_WHITESPACE +REPORT_NDIFF
+    ... # doctest: +NORMALIZE_WHITESPACE
     Test-module import failures:
     <BLANKLINE>
     Module: sample2.sampletests_i

--- a/src/zope/testrunner/tests/testrunner-errors.txt
+++ b/src/zope/testrunner/tests/testrunner-errors.txt
@@ -724,7 +724,7 @@ Then run the tests:
     >>> sys.argv = ('test --tests-pattern ^sampletests(f|_i)?$ --layer 1 '
     ...            ).split()
     >>> testrunner.run_internal(defaults)
-    ... # doctest: +NORMALIZE_WHITESPACE
+    ... # doctest: +NORMALIZE_WHITESPACE +REPORT_NDIFF
     Test-module import failures:
     <BLANKLINE>
     Module: sample2.sampletests_i


### PR DESCRIPTION
Fixed: Using the -j option to run tests in multiple processes caused tests that used the multiprocessing package to hang (because the testrunner replaced sys.stdin with an unclosable object).