### PR TITLE
Make the 'subunit' support purely optional.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 sudo: false
 language: python
-python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-    - pypy
-    - pypy3
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+env:
+    - TOXENV=py27
+    - TOXENV=py27-subunit
+    - TOXENV=pypy
+    - TOXENV=pypy-subunit
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy3
 install:
-    - pip install .
+    - pip install tox
 script:
-    - python setup.py -q test -q
+    - tox
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ python:
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 zope.testrunner Changelog
 *************************
 
+4.6.0 (unreleased)
+==================
+
+- Make the ``subunit`` support purely optional: applications which have
+  been getting the dependencies via ``zope.testrunner`` should either add
+  ``zope.testrunner[subunit]`` to their ``install_requires`` or else
+  depend directly on ``python-subunit``.
+
 4.5.1 (2016-06-20)
 ==================
 

--- a/src/zope/testrunner/tests/testrunner-subunit.txt
+++ b/src/zope/testrunner/tests/testrunner-subunit.txt
@@ -2,7 +2,15 @@ Subunit Output
 ==============
 
 Subunit is a streaming protocol for interchanging test results. More
-information can be found at https://launchpad.net/subunit.
+information can be found at https://launchpad.net/subunit.  To enable
+support for ``subunit``, install it and its dependencies via the
+``zope.testrunner`` extra:
+
+    $ pip install zope.testrunner[subunit]
+
+or directly:
+
+    $ pip install python-subunit
 
 First we need to make a temporary copy of the entire testing directory:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,pypy,py33,py34,py35,pypy3
+    py27,pypy,py33,py34,py35,pypy3,py27-subunit,pypy-subunit
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,19 @@ envlist =
 deps =
     zope.testing
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
-[testenv:py27]
+[testenv:py27-subunit]
 deps =
     {[testenv]deps}
     python-subunit
 
-[testenv:pypy]
+[testenv:py34-subunit]
+deps =
+    {[testenv]deps}
+    python-subunit
+
+[testenv:pypy-subunit]
 deps =
     {[testenv]deps}
     python-subunit

--- a/tox.ini
+++ b/tox.ini
@@ -5,20 +5,6 @@ envlist =
 [testenv]
 deps =
     zope.testing
+    subunit: python-subunit
 commands =
     python setup.py -q test -q
-
-[testenv:py27-subunit]
-deps =
-    {[testenv]deps}
-    python-subunit
-
-[testenv:py34-subunit]
-deps =
-    {[testenv]deps}
-    python-subunit
-
-[testenv:pypy-subunit]
-deps =
-    {[testenv]deps}
-    python-subunit


### PR DESCRIPTION
Applications which have been getting the dependencies via `zope.testrunner` should either add `zope.testrunner[subunit]` to their `install_requires`, or else depend directly on `python-subunit`.

The rationale for the change is that `python-subunit` is a heavy dependency, and that those who want the feature are likely to have it installed anyway.

/cc @multani, @rbtcollins, @menesis, @kedder, @mgedmin 