### PR TITLE
Add a new option to disable reporting for known threads left behind.

### DIFF
--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -250,6 +250,9 @@ reporting.add_option(
     dest='ignore_new_threads',
     help="""\
 If a thread with this name is left behind, don't report this at the end.
+This is a case-sensitive regular expression, used in match mode.
+This option can be used multiple times. If a thread name matches any of them,
+it will be ignored.
 """)
 
 

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -244,7 +244,7 @@ When there is a doctest failure, show it as a context diff.
 """)
 
 reporting.add_option(
-    '--ignore_new_thread',
+    '--ignore-new-thread',
     action="append",
     default=[],
     dest='ignore_new_threads',

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -243,6 +243,16 @@ reporting.add_option(
 When there is a doctest failure, show it as a context diff.
 """)
 
+reporting.add_option(
+    '--ignore_new_thread',
+    action="append",
+    default=[],
+    dest='ignore_new_threads',
+    help="""\
+If a thread with this name is left behind, don't report this at the end.
+""")
+
+
 parser.add_option_group(reporting)
 
 ######################################################################

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -849,10 +849,13 @@ class TestResult(unittest.TestResult):
                 #       printed for every subsequent test.
 
         # Did the test leave any new threads behind?
-        new_threads = [t for t in threading.enumerate()
-                         if (t.isAlive()
-                             and
-                             t not in self._threads)]
+        new_threads = []
+        for t in threading.enumerate():
+            if t.isAlive():
+                if t not in self._threads:
+                    if t.name not in self.options.ignore_new_threads:
+                        new_threads.append(t)
+
         if new_threads:
             self.options.output.test_threads(test, new_threads)
 

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -851,10 +851,10 @@ class TestResult(unittest.TestResult):
         # Did the test leave any new threads behind?
         new_threads = []
         for t in threading.enumerate():
-            if t.isAlive():
-                if t not in self._threads:
-                    if t.name not in self.options.ignore_new_threads:
-                        new_threads.append(t)
+            if t.isAlive() and t not in self._threads:
+                if not any([re.match(p, t.name)
+                            for p in self.options.ignore_new_threads]):
+                    new_threads.append(t)
 
         if new_threads:
             self.options.output.test_threads(test, new_threads)

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -233,6 +233,7 @@ def test_suite():
         'testrunner-shuffle.txt',
         'testrunner-eggsupport.txt',
         'testrunner-stops-when-stop-on-error.txt',
+        'testrunner-new-threads.txt',
         setUp=setUp, tearDown=tearDown,
         optionflags=optionflags,
         checker=checker),

--- a/src/zope/testrunner/tests/testrunner-ex/new_threads.py
+++ b/src/zope/testrunner/tests/testrunner-ex/new_threads.py
@@ -1,0 +1,14 @@
+import time
+import threading
+import unittest
+
+
+class Mythread(threading.Thread):
+    # The default includes a timestamp when the thread was started.
+    def __repr__(self):
+        return "<Thread(%s)>" % self.name
+
+
+class TestNewThreadsReporting(unittest.TestCase):
+    def test_leave_thread_behind(self):
+        Mythread(name='t1', target=time.sleep, args=[1]).start()

--- a/src/zope/testrunner/tests/testrunner-new-threads.txt
+++ b/src/zope/testrunner/tests/testrunner-new-threads.txt
@@ -1,9 +1,9 @@
 Threads Reporting
-=============================
+=================
 
 For each test zope.testrunner checks if new threads are left behind.
 
-	>>> import time
+    >>> import time
     >>> import os
     >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
     >>> defaults = ['--path', directory_with_tests]
@@ -19,12 +19,12 @@ For each test zope.testrunner checks if new threads are left behind.
       Ran 1 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
-	>>> time.sleep(1)
+    >>> time.sleep(1)
 
 
 It is possible to ignore this reporting for known threads.
 
-	>>> import time
+    >>> import time
     >>> import os
     >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
     >>> defaults = ['--path', directory_with_tests]
@@ -37,4 +37,4 @@ It is possible to ignore this reporting for known threads.
       Ran 1 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
-	>>> time.sleep(1)
+    >>> time.sleep(1)

--- a/src/zope/testrunner/tests/testrunner-new-threads.txt
+++ b/src/zope/testrunner/tests/testrunner-new-threads.txt
@@ -30,7 +30,7 @@ It is possible to ignore this reporting for known threads.
     >>> defaults = ['--path', directory_with_tests]
 
     >>> from zope import testrunner
-    >>> args = ['test', '--tests-pattern', '^new_threads$', '--ignore_new_thread=t1']
+    >>> args = ['test', '--tests-pattern', '^new_threads$', '--ignore-new-thread=t1']
     >>> _ = testrunner.run_internal(defaults, args)
     Running zope.testrunner.layer.UnitTests tests:
       Set up zope.testrunner.layer.UnitTests in N.NNN seconds.

--- a/src/zope/testrunner/tests/testrunner-new-threads.txt
+++ b/src/zope/testrunner/tests/testrunner-new-threads.txt
@@ -1,0 +1,40 @@
+Threads Reporting
+=============================
+
+For each test zope.testrunner checks if new threads are left behind.
+
+	>>> import time
+    >>> import os
+    >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
+    >>> defaults = ['--path', directory_with_tests]
+
+    >>> from zope import testrunner
+    >>> args = ['test', '--tests-pattern', '^new_threads$']
+    >>> _ = testrunner.run_internal(defaults, args)
+    Running zope.testrunner.layer.UnitTests tests:
+      Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+    The following test left new threads behind:
+    test_leave_thread_behind (new_threads.TestNewThreadsReporting)
+    New thread(s): [<Thread(t1)>]
+      Ran 1 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+	>>> time.sleep(1)
+
+
+It is possible to ignore this reporting for known threads.
+
+	>>> import time
+    >>> import os
+    >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
+    >>> defaults = ['--path', directory_with_tests]
+
+    >>> from zope import testrunner
+    >>> args = ['test', '--tests-pattern', '^new_threads$', '--ignore_new_thread=t1']
+    >>> _ = testrunner.run_internal(defaults, args)
+    Running zope.testrunner.layer.UnitTests tests:
+      Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+      Ran 1 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+	>>> time.sleep(1)


### PR DESCRIPTION
Hi,
The application I'm testing is using a library which, on purpose, leaves threads behind.
So currently for *each* test function something like this is written to the console.

```
The following test left new threads behind:
test_nbi_csv_import_from_file_with_restrictions (ax.axtract_zope.tests.test_axtract.TestAxtract)
New thread(s): [<Thread(pymongo_server_monitor_thread, started daemon -1276036288)>, <Thread(pymongo_server_monitor_thread, started daemon -1314915520)>]
```

Which is very annoying, especially if there a hundreds of tests.
I looked into this library to get rid this behaviour, but it looks to me that they have good reasons for their implementation.

Therefore I'm opening this pull requests to allow filtering before reporting a thread left behind.