### PR TITLE
Force Python 3.5 to work on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=py35
-    - python: pypy3.3-5.5-alpha
+    - python: pypy3.3-5.2-alpha1
       env: TOXENV=pypy3
 env:
     - TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ matrix:
       env: TOXENV=py35
     - python: pypy3.3-5.2-alpha1
       env: TOXENV=pypy3
-env:
-    - TOXENV=py27
-    - TOXENV=py27-subunit
-    - TOXENV=pypy
-    - TOXENV=pypy-subunit
-    - TOXENV=py33
-    - TOXENV=py34
+      ##env:
+      ##    - TOXENV=py27
+      ##    - TOXENV=py27-subunit
+      ##    - TOXENV=pypy
+      ##    - TOXENV=pypy-subunit
+      ##    - TOXENV=py33
+      ##    - TOXENV=py34
 install:
-    - pip install tox
+    - pip install -U pip setuptools tox virtualenv
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=py35
-    - python: pypy3.3-5.2-alpha1
+    - python: pypy3.3-5.5-alpha
       env: TOXENV=pypy3
 env:
     - TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,21 @@
 sudo: false
 language: python
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3.3-5.2-alpha1
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35
-    - python: pypy3.3-5.2-alpha1
-      env: TOXENV=pypy3
-      ##env:
-      ##    - TOXENV=py27
-      ##    - TOXENV=py27-subunit
-      ##    - TOXENV=pypy
-      ##    - TOXENV=pypy-subunit
-      ##    - TOXENV=py33
-      ##    - TOXENV=py34
+    - python: 2.7
+      env: TOXENV=py27-subunit
+    - python: pypy
+      env: TOXENV=pypy-subunit
 install:
-    - pip install -U pip setuptools tox virtualenv
+    - pip install tox-travis
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - 3.6
   - pypy
   - pypy3.3-5.2-alpha1
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=py35
+    - python: pypy3.3-5.2-alpha1
+      env: TOXENV=pypy3
 env:
     - TOXENV=py27
     - TOXENV=py27-subunit
@@ -11,7 +13,6 @@ env:
     - TOXENV=pypy-subunit
     - TOXENV=py33
     - TOXENV=py34
-    - TOXENV=pypy3
 install:
     - pip install tox
 script:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,11 @@ sys.path = %s
 import os
 os.chdir('%s')
 
+# The following unused imports are dark magic that makes the tests pass on
+# Python 3.5 on Travis CI.  I do not understand why.
+import zope.exceptions.exceptionformatter
+import zope.testing
+
 import zope.testrunner
 if __name__ == '__main__':
     zope.testrunner.run([


### PR DESCRIPTION
Reasons to accept this:
- it makes Python 3.5 pass on Travis CI
- it makes `tox --develop` pass locally
- it makes PyPy3 pass on Travis CI

Reasons to reject this:
- this is black magic workaround that papers around the problem instead of fixing it
- it conflates two fixes (py35 and pypy3) in one pull request