### PR TITLE
Automatically enable the default warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.5
   - 3.6
   - pypy
-  - pypy3.3-5.2-alpha1
+  - pypy3
 install:
     - pip install tox-travis
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,15 @@
 zope.testrunner Changelog
 *************************
 
-4.7.1 (unreleased)
+4.8.0 (unreleased)
 ==================
 
-- TBD
+- Automatically enable ``DeprecationWarning`` when running tests. This
+  is recommended by the Python core developers and matches the
+  behaviour of the ``unittest`` module. This can be overridden with
+  Python command-line options (``-W``) or environment variables
+  (``PYTHONWARNINGS``). See `issue 54
+  <https://github.com/zopefoundation/zope.testrunner/issues/54>`_.
 
 4.7.0 (2017-05-30)
 ==================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,9 @@ environment:
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
+  - pip install -U setuptools
   # NB: pip install -e .[test] fails for obscure namespace package reasons
-  - pip install .[test]
+  - pip install -U .[test]
 
 build: false
 

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,12 @@
 # When developing and releasing this package, please follow the documented
 # Zope Toolkit policies as described by this documentation.
 ##############################################################################
-version = '4.7.1.dev0'
-
 import os
 import sys
 from setuptools import setup
 from setuptools.command.test import test
 
+version = '4.8.0.dev0'
 
 INSTALL_REQUIRES = [
     'setuptools',
@@ -55,7 +54,7 @@ import zope.testing
 import zope.testrunner
 if __name__ == '__main__':
     zope.testrunner.run([
-        '--test-path', %r, '-c'
+        '--test-path', %r, '-c',
         ])
 """
 
@@ -77,12 +76,12 @@ class custom_test(test):
 
     def run_tests(self):
         import tempfile
-        fd, filename = tempfile.mkstemp(prefix='temprunner', text=True)
-        scriptfile = open(filename, 'w')
         script = CUSTOM_TEST_TEMPLATE % (
             sys.path, os.path.abspath(os.curdir), os.path.abspath('src'))
-        scriptfile.write(script)
-        scriptfile.close()
+        _fd, filename = tempfile.mkstemp(prefix='temprunner', text=True)
+        with open(filename, 'w') as scriptfile:
+            scriptfile.write(script)
+            scriptfile.close()
 
         import subprocess
         process = subprocess.Popen([sys.executable, filename])
@@ -96,8 +95,12 @@ class custom_test(test):
             sys.stderr.flush()
         sys.exit(rc)
 
+def read(*names):
+    with open(os.path.join(*names)) as f:
+        return f.read()
+
 chapters = '\n'.join([
-    open(os.path.join('src', 'zope', 'testrunner', 'tests', name)).read()
+    read('src', 'zope', 'testrunner', 'tests', name)
     for name in (
         'testrunner.txt',
         'testrunner-simple.txt',
@@ -120,14 +123,14 @@ chapters = '\n'.join([
         'testrunner-edge-cases.txt',
 
         # The following seems to cause weird unicode in the output: :(
-             'testrunner-errors.txt',
+        'testrunner-errors.txt',
 
     )])
 
-long_description=(
-    open('README.rst').read()
+long_description = (
+    read('README.rst')
     + '\n' +
-    open('CHANGES.rst').read()
+    read('CHANGES.rst')
     + '\n' +
     'Detailed Documentation\n'
     '**********************\n'
@@ -137,14 +140,14 @@ long_description=(
 setup(
     name='zope.testrunner',
     version=version,
-    url='http://pypi.python.org/pypi/zope.testrunner',
+    url='https://github.com/zopefoundation/zope.testrunner',
     license='ZPL 2.1',
     description='Zope testrunner script.',
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     packages=["zope", "zope.testrunner", "zope.testrunner.tests.testrunner-ex"],
-    package_dir = {'': 'src'},
+    package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -164,20 +167,20 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",
-        ],
+    ],
     namespace_packages=['zope',],
-    install_requires = INSTALL_REQUIRES,
-    tests_require = TESTS_REQUIRE,
-    extras_require = EXTRAS_REQUIRE,
-    entry_points = {
+    install_requires=INSTALL_REQUIRES,
+    tests_require=TESTS_REQUIRE,
+    extras_require=EXTRAS_REQUIRE,
+    entry_points={
         'console_scripts':
             ['zope-testrunner = zope.testrunner:run',],
         'distutils.commands': [
             'ftest = zope.testrunner.eggsupport:ftest',],
-        },
-    include_package_data = True,
-    zip_safe = False,
-    cmdclass = {
+    },
+    include_package_data=True,
+    zip_safe=False,
+    cmdclass={
         'test': custom_test,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ class custom_test(test):
         _fd, filename = tempfile.mkstemp(prefix='temprunner', text=True)
         with open(filename, 'w') as scriptfile:
             scriptfile.write(script)
-            scriptfile.close()
 
         import subprocess
         process = subprocess.Popen([sys.executable, filename])

--- a/src/zope/testrunner/__init__.py
+++ b/src/zope/testrunner/__init__.py
@@ -18,20 +18,27 @@ import os
 import sys
 
 
-def run(defaults=None, args=None, script_parts=None, cwd=None):
+def run(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
     """Main runner function which can be and is being used from main programs.
 
     Will execute the tests and exit the process according to the test result.
 
+    .. versionchanged:: 4.8.0
+       Add the *warnings* keyword argument. See :class:`zope.testrunner.runner.Runner`
+
     """
-    failed = run_internal(defaults, args, script_parts=script_parts, cwd=cwd)
+    failed = run_internal(defaults, args, script_parts=script_parts, cwd=cwd,
+                          warnings=warnings)
     sys.exit(int(failed))
 
 
-def run_internal(defaults=None, args=None, script_parts=None, cwd=None):
+def run_internal(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
     """Execute tests.
 
     Returns whether errors or failures occured during testing.
+
+    .. versionchanged:: 4.8.0
+       Add the *warnings* keyword argument. See :class:`zope.testrunner.runner.Runner`
 
     """
     if script_parts is None:
@@ -40,7 +47,7 @@ def run_internal(defaults=None, args=None, script_parts=None, cwd=None):
         cwd = os.getcwd()
     # XXX Bah. Lazy import to avoid circular/early import problems
     from zope.testrunner.runner import Runner
-    runner = Runner(defaults, args, script_parts=script_parts, cwd=cwd)
+    runner = Runner(defaults, args, script_parts=script_parts, cwd=cwd, warnings=warnings)
     runner.run()
     return runner.failed
 

--- a/src/zope/testrunner/tests/test_runner.py
+++ b/src/zope/testrunner/tests/test_runner.py
@@ -13,7 +13,7 @@
 ##############################################################################
 """Unit tests for the testrunner's runner logic
 """
-
+import sys
 import unittest
 
 from zope.testrunner import runner
@@ -173,10 +173,34 @@ class TestLayerOrdering(unittest.TestCase):
         # Does that matter?  The class diagram is symmetric, so I think not.
 
     def test_FakeInputContinueGenerator_close(self):
-        # multiprocessing (and likely other forkful frameworks want to
+        # multiprocessing (and likely other forkful frameworks) want to
         # close sys.stdin.  The test runner replaces sys.stdin with a
         # FakeInputContinueGenerator for some reason. It should be
         # closeable.
 
         f = runner.FakeInputContinueGenerator()
         f.close()
+
+class TestWarnings(unittest.TestCase):
+
+    @unittest.skipIf(sys.warnoptions, "Only done if no user override")
+    def test_warning_filter_default(self):
+        # When we run tests, we run them with a 'default' simplefilter.
+        # Note that this test will fail if PYTHONWARNINGS is set,
+        # or a -W option was given, so we skip it
+        import warnings
+        # Save the current filters, ignoring the compiled regexes,
+        # which can't be compared.
+        old_filters = [(f[0], f[2], 4) for f in warnings.filters]
+        with warnings.catch_warnings():
+            # Set up just like the runner does
+            warnings.simplefilter('default')
+            warnings.filterwarnings('module',
+                                    category=DeprecationWarning,
+                                    message=r'Please use assert\w+ instead.')
+            new_filters = [(f[0], f[2], 4) for f in warnings.filters]
+
+        # For some reason, catch_warnings doesn't fully reset things,
+        # and we wind up with some duplicate entries in new_filters
+        self.assertEqual(set(old_filters), set(new_filters))
+        warnings.warn("This should be visible by default", DeprecationWarning)

--- a/src/zope/testrunner/tests/testrunner-subprocess-errors.txt
+++ b/src/zope/testrunner/tests/testrunner-subprocess-errors.txt
@@ -23,6 +23,9 @@ reporting of that error:
     ...     def __init__(self, out, err):
     ...         self.stdout = FakeStdout(out)
     ...         self.stderr = FakeStderr(err)
+    ...     def kill(self):
+    ...         pass
+    ...     communicate = kill
 
     >>> class FakePopen(object):
     ...     def __init__(self, out, err):


### PR DESCRIPTION
Fixes #54

The handling of the arguments and warnings is directly lifted from ``unittest``.

I introduced a new method, run_tests_with_warnings, that calls the pre-existing run_tests. In the (unlikely?) event of subclasses that override run_tests, this will ensure that they get the warnings by
default. It will also allow subclasses to change warning behaviour without changing test behaviour.

This started producing a bunch of ResourceWarnings under Python 3 for unclosed files and un-waited-for child process, and that broke a doctest, so I fixed that in spawn_layer_in_subprocess.