### PR TITLE
Enable warnings during test discovery.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ zope.testrunner Changelog
 4.8.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Enable ``DeprecationWarning`` earlier, when discovering test
+  modules. This lets warnings that are raised on import (such as those
+  produced by ``zope.deprecation.moved``) be reported. See `issue 57
+  <https://github.com/zopefoundation/zope.testrunner/issues/57>`_.
 
 
 4.8.0 (2017-11-10)


### PR DESCRIPTION
Fixes #57

Refactor the warning enablement into its own (protected) method (since we need to use it during the already-public 'run' method) and go back to just using `run_tests` Subclasses can still override that method to change warning behaviour.

I did not add a specific test case for this. Because zope.testrunner runs its own tests, trying to test a feature that issued a warning would always succeed (because warnings are enabled when tests are run), without trying to do a bunch of messing with the filters or subprocesses.