### PR TITLE
Enable coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,12 @@
 [run]
 source = zope.testrunner
 parallel = true
+omit =
+    # These files are definitely imported and executed,
+    # but for some reason don't show up as such.
+    # See testrunner-knit
+    src/zope/testrunner/tests/testrunner-ex-pp-products/more/sampletests.py
+    src/zope/testrunner/tests/testrunner-ex-pp-products/sampletests.py
 
 [report]
 precision = 2
@@ -10,3 +16,5 @@ exclude_lines =
     raise NotImplementedError
     self.fail
     raise AssertionError
+    if is_jython:
+    if sys.platform == 'win32':

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source = zope.testrunner
+parallel = true
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ develop-eggs/
 tags
 .tox
 parts/
+.coverage
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ tags
 .tox
 parts/
 .coverage
+.coverage.*
 htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,20 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
   - pypy
   - pypy3
 install:
-    - pip install tox-travis
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - tox
+    - coverage run setup.py -q test -q
+after_success:
+    - coverage combine
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - pip install -U coverage coveralls
     - pip install -U -e .[test]
 script:
-    - coverage run setup.py -q test -q
+    - COVERAGE_PROCESS_START=`pwd`/.coveragerc coverage run setup.py -q test -q
 after_success:
     - coverage combine
     - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ zope.testrunner Changelog
 4.8.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Drop support for Python 3.3.
+
+- Enable test coverage reporting on coveralls.io and in tox.ini.
 
 
 4.8.1 (2017-11-12)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
-include *.rst *.py buildout.cfg tox.ini *.yml
+include *.rst
+include *.py
+include buildout.cfg
+include tox.ini
+include *.yml
+include .coveragerc
+
 recursive-include src *.py *.txt *.test

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ zope.testrunner
 .. image:: https://travis-ci.org/zopefoundation/zope.testrunner.svg?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.testrunner
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.testrunner/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.testrunner?branch=master
+
+
 .. contents::
 
 This package provides a flexible test runner with layer support.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test
 
-version = '4.8.2.dev0'
+version = '4.9.0.dev0'
 
 INSTALL_REQUIRES = [
     'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,13 @@ CUSTOM_TEST_TEMPLATE = """\
 import sys
 sys.path = %r
 
+try:
+    import coverage
+except ImportError:
+    pass
+else:
+    coverage.process_startup()
+
 import os
 os.chdir(%r)
 
@@ -158,7 +165,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/src/zope/testrunner/coverage.py
+++ b/src/zope/testrunner/coverage.py
@@ -28,7 +28,7 @@ from zope.testrunner.find import test_dirs
 # trace can be set, so that debugging still works.
 osettrace = sys.settrace
 def settrace(trace):
-    if trace is None:
+    if trace is None: # pragma: no cover
         return
     osettrace(trace)
 
@@ -81,7 +81,7 @@ class TestTrace(trace.Trace):
         self.started = False
 
 
-class TestIgnore:
+class TestIgnore(object):
 
     def __init__(self, directories):
         self._test_dirs = [self._filenameFormat(d[0]) + os.path.sep

--- a/src/zope/testrunner/profiling.py
+++ b/src/zope/testrunner/profiling.py
@@ -16,7 +16,6 @@
 
 import os
 import glob
-import sys
 import tempfile
 import zope.testrunner.feature
 
@@ -52,55 +51,10 @@ else:
     available_profilers['cProfile'] = CProfiler
 
 
-# some Linux distributions don't include the profiler, which hotshot uses
-if not sys.hexversion >= 0x02060000:
-    # Hotshot is not maintained any longer in 2.6. It does not support 
-    # merging to hotshot files. Thus we won't use it in python2.6 and
-    # onwards
-    try:
-        import hotshot
-        import hotshot.stats
-    except ImportError:
-        pass
-    else:
-        class HotshotProfiler(object):
-            """hotshot interface"""
-
-            def __init__(self, filepath):
-                self.profiler = hotshot.Profile(filepath)
-                self.enable = self.profiler.start
-                self.disable = self.profiler.stop
- 
-            def finish(self):
-                self.profiler.close()
-
-            def loadStats(self, prof_glob):
-                stats = None
-                for file_name in glob.glob(prof_glob):
-                    loaded = hotshot.stats.load(file_name)
-                    if stats is None:
-                        stats = loaded
-                    else:
-                        stats.add(loaded)
-                return stats
-
-        available_profilers['hotshot'] = HotshotProfiler
-
-
 class Profiling(zope.testrunner.feature.Feature):
 
     def __init__(self, runner):
         super(Profiling, self).__init__(runner)
-
-        if (self.runner.options.profile
-            and sys.version_info[:3] <= (2,4,1)
-            and __debug__):
-            self.runner.options.output.error(
-                'Because of a bug in Python < 2.4.1, profiling '
-                'during tests requires the -O option be passed to '
-                'Python (not the test runner).')
-            sys.exit()
-
         self.active = bool(self.runner.options.profile)
         self.profiler = self.runner.options.profile
 

--- a/src/zope/testrunner/profiling.py
+++ b/src/zope/testrunner/profiling.py
@@ -13,42 +13,39 @@
 ##############################################################################
 """Profiler support for the test runner
 """
-
-import os
+import cProfile
 import glob
+import os
+import pstats
 import tempfile
+
 import zope.testrunner.feature
 
 available_profilers = {}
 
 
-try:
-    import cProfile
-    import pstats
-except ImportError: # pragma: no cover (Where could this fail?)
-    pass
-else:
-    class CProfiler(object):
-        """cProfiler"""
-        def __init__(self, filepath):
-            self.filepath = filepath
-            self.profiler = cProfile.Profile()
-            self.enable = self.profiler.enable
-            self.disable = self.profiler.disable
 
-        def finish(self):
-            self.profiler.dump_stats(self.filepath)
+class CProfiler(object):
+    """cProfiler"""
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self.profiler = cProfile.Profile()
+        self.enable = self.profiler.enable
+        self.disable = self.profiler.disable
 
-        def loadStats(self, prof_glob):
-            stats = None
-            for file_name in glob.glob(prof_glob):
-                if stats is None:
-                    stats = pstats.Stats(file_name)
-                else:
-                    stats.add(file_name)
-            return stats
+    def finish(self):
+        self.profiler.dump_stats(self.filepath)
 
-    available_profilers['cProfile'] = CProfiler
+    def loadStats(self, prof_glob):
+        stats = None
+        for file_name in glob.glob(prof_glob):
+            if stats is None:
+                stats = pstats.Stats(file_name)
+            else:
+                stats.add(file_name)
+        return stats
+
+available_profilers['cProfile'] = CProfiler
 
 
 class Profiling(zope.testrunner.feature.Feature):

--- a/src/zope/testrunner/profiling.py
+++ b/src/zope/testrunner/profiling.py
@@ -25,7 +25,7 @@ available_profilers = {}
 try:
     import cProfile
     import pstats
-except ImportError:
+except ImportError: # pragma: no cover (Where could this fail?)
     pass
 else:
     class CProfiler(object):

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -281,23 +281,17 @@ def test_suite():
             ]),
         )
     )
-    try:
-        import cProfile
-        import pstats
-    except ImportError: # pragma: no cover (where is this true?)
-        pass
-    else:
-        suites.append(
-            doctest.DocFileSuite(
-                'testrunner-profiling-cprofiler.txt',
-                setUp=setUp, tearDown=tearDown,
-                optionflags=optionflags,
-                checker=renormalizing.RENormalizing([
-                    (re.compile(r'tests_profile[.]\S*[.]prof'),
-                     'tests_profile.*.prof'),
-                ]),
-            )
+    suites.append(
+        doctest.DocFileSuite(
+            'testrunner-profiling-cprofiler.txt',
+            setUp=setUp, tearDown=tearDown,
+            optionflags=optionflags,
+            checker=renormalizing.RENormalizing([
+                (re.compile(r'tests_profile[.]\S*[.]prof'),
+                 'tests_profile.*.prof'),
+            ]),
         )
+    )
 
     suites.append(
         doctest.DocFileSuite(

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -31,7 +31,7 @@ if sys.platform == 'win32':
     checker = renormalizing.RENormalizing([
         # 2.5 changed the way pdb reports exceptions
         (re.compile(r"<class 'exceptions.(\w+)Error'>:"),
-                    r'exceptions.\1Error:'),
+         r'exceptions.\1Error:'),
 
         #rewrite pdb prompt to ... the current location
         #windows, py2.4 pdb seems not to put the '>' on doctest locations
@@ -41,9 +41,9 @@ if sys.platform == 'win32':
         #rewrite pdb prompt to ... the current location
         (re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
 
-        (re.compile(r"<module>"),(r'?')),
+        (re.compile(r"<module>"), (r'?')),
         (re.compile(r"<type 'exceptions.(\w+)Error'>:"),
-                    r'exceptions.\1Error:'),
+         r'exceptions.\1Error:'),
 
         # testtools content formatter is used to mime-encode
         # tracebacks when the SubunitOutputFormatter is used, and the
@@ -74,7 +74,7 @@ if sys.platform == 'win32':
         (re.compile('( |")[^\n]+testrunner-ex'), r'\1testrunner-ex'),
         (re.compile('( |")[^\n]+testrunner.py'), r'\1testrunner.py'),
         (re.compile(r'> [^\n]*(doc|unit)test[.]py\(\d+\)'),
-                    r'\1test.py(NNN)'),
+         r'\1test.py(NNN)'),
         (re.compile(r'[.]py\(\d+\)'), r'.py(NNN)'),
         (re.compile(r'[.]py:\d+'), r'.py:NNN'),
         (re.compile(r' line \d+,', re.IGNORECASE), r' Line NNN,'),
@@ -114,14 +114,14 @@ else:
     checker = renormalizing.RENormalizing([
         # 2.5 changed the way pdb reports exceptions
         (re.compile(r"<class 'exceptions.(\w+)Error'>:"),
-                    r'exceptions.\1Error:'),
+         r'exceptions.\1Error:'),
 
         #rewrite pdb prompt to ... the current location
         (re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
 
-        (re.compile(r"<module>"),(r'?')),
+        (re.compile(r"<module>"), (r'?')),
         (re.compile(r"<type 'exceptions.(\w+)Error'>:"),
-                    r'exceptions.\1Error:'),
+         r'exceptions.\1Error:'),
 
         #this is a magic to put linefeeds into the doctest
         #on win it takes one step, linux is crazy about the same...
@@ -136,7 +136,7 @@ else:
         (re.compile('( |"|\')[^\'\n]+testrunner-ex'), r'\1testrunner-ex'),
         (re.compile('( |"|\')[^\'\n]+testrunner.py'), r'\1testrunner.py'),
         (re.compile(r'> [^\n]*(doc|unit)test[.]py\(\d+\)'),
-                    r'\1test.py(NNN)'),
+         r'\1test.py(NNN)'),
         (re.compile(r'[.]py\(\d+\)'), r'.py(NNN)'),
         (re.compile(r'[.]py:\d+'), r'.py:NNN'),
         (re.compile(r' line \d+,', re.IGNORECASE), r' Line NNN,'),
@@ -205,109 +205,99 @@ def test_suite():
                    doctest.REPORT_NDIFF)
     suites = [
         doctest.DocFileSuite(
-        'testrunner-arguments.txt',
-        'testrunner-coverage.txt',
-        'testrunner-debugging-layer-setup.test',
-        'testrunner-debugging-import-failure.test',
-        'testrunner-debugging-nonprintable-exc.test',
-        'testrunner-debugging.txt',
-        'testrunner-edge-cases.txt',
-        'testrunner-errors.txt',
-        'testrunner-layers-api.txt',
-        'testrunner-layers-instances.txt',
-        'testrunner-layers-buff.txt',
-        'testrunner-subprocess-errors.txt',
-        'testrunner-layers-cantfind.txt',
-        'testrunner-layers-cwd.txt',
-        'testrunner-layers-ntd.txt',
-        'testrunner-layers-topological-sort.txt',
-        'testrunner-layers.txt',
-        'testrunner-progress.txt',
-        'testrunner-colors.txt',
-        'testrunner-simple.txt',
-        'testrunner-nestedcode.txt',
-        'testrunner-test-selection.txt',
-        'testrunner-verbose.txt',
-        'testrunner-repeat.txt',
-        'testrunner-knit.txt',
-        'testrunner-shuffle.txt',
-        'testrunner-eggsupport.txt',
-        'testrunner-stops-when-stop-on-error.txt',
-        'testrunner-new-threads.txt',
-        setUp=setUp, tearDown=tearDown,
-        optionflags=optionflags,
-        checker=checker),
+            'testrunner-arguments.txt',
+            'testrunner-coverage.txt',
+            'testrunner-debugging-layer-setup.test',
+            'testrunner-debugging-import-failure.test',
+            'testrunner-debugging-nonprintable-exc.test',
+            'testrunner-debugging.txt',
+            'testrunner-edge-cases.txt',
+            'testrunner-errors.txt',
+            'testrunner-layers-api.txt',
+            'testrunner-layers-instances.txt',
+            'testrunner-layers-buff.txt',
+            'testrunner-subprocess-errors.txt',
+            'testrunner-layers-cantfind.txt',
+            'testrunner-layers-cwd.txt',
+            'testrunner-layers-ntd.txt',
+            'testrunner-layers-topological-sort.txt',
+            'testrunner-layers.txt',
+            'testrunner-progress.txt',
+            'testrunner-colors.txt',
+            'testrunner-simple.txt',
+            'testrunner-nestedcode.txt',
+            'testrunner-test-selection.txt',
+            'testrunner-verbose.txt',
+            'testrunner-repeat.txt',
+            'testrunner-knit.txt',
+            'testrunner-shuffle.txt',
+            'testrunner-eggsupport.txt',
+            'testrunner-stops-when-stop-on-error.txt',
+            'testrunner-new-threads.txt',
+            setUp=setUp, tearDown=tearDown,
+            optionflags=optionflags,
+            checker=checker),
         doctest.DocTestSuite('zope.testrunner'),
         doctest.DocTestSuite('zope.testrunner.coverage',
-            optionflags=optionflags),
+                             optionflags=optionflags),
         doctest.DocTestSuite('zope.testrunner.options'),
         doctest.DocTestSuite('zope.testrunner.find'),
-        ]
+    ]
 
     # PyPy uses a different garbage collector
     if hasattr(gc, 'get_threshold'):
         suites.append(
             doctest.DocFileSuite(
-            'testrunner-gc.txt',
-            setUp=setUp, tearDown=tearDown,
-            optionflags=optionflags,
-            checker=checker))
+                'testrunner-gc.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
 
     # PyPy does not support sourceless imports, apparently (tried version 1.9)
     if 'PyPy' not in sys.version and not sys.dont_write_bytecode:
         suites.append(
             doctest.DocFileSuite(
-            'testrunner-wo-source.txt',
-            setUp=setUp, tearDown=tearDown,
-            optionflags=optionflags,
-            checker=checker))
+                'testrunner-wo-source.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
 
     if sys.platform == 'win32':
         suites.append(
             doctest.DocFileSuite(
-            'testrunner-coverage-win32.txt',
+                'testrunner-coverage-win32.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
+
+    suites.append(
+        doctest.DocFileSuite(
+            'testrunner-profiling.txt',
             setUp=setUp, tearDown=tearDown,
             optionflags=optionflags,
-            checker=checker))
-
-    # Python <= 2.4.1 had a bug that prevented hotshot from running in
-    # non-optimize mode
-    if sys.version_info[:3] > (2,4,1) or not __debug__:
-        # some Linux distributions don't include the profiling module (which
-        # hotshot.stats depends on)
-        try:
-            import hotshot.stats
-        except ImportError:
-            pass
-        else:
-            suites.append(
-                doctest.DocFileSuite(
-                    'testrunner-profiling.txt',
-                    setUp=setUp, tearDown=tearDown,
-                    optionflags=optionflags,
-                    checker = renormalizing.RENormalizing([
-                        (re.compile(r'tests_profile[.]\S*[.]prof'),
-                         'tests_profile.*.prof'),
-                        ]),
-                    )
-                )
-        try:
-            import cProfile
-            import pstats
-        except ImportError:
-            pass
-        else:
-            suites.append(
-                doctest.DocFileSuite(
-                    'testrunner-profiling-cprofiler.txt',
-                    setUp=setUp, tearDown=tearDown,
-                    optionflags=optionflags,
-                    checker = renormalizing.RENormalizing([
-                        (re.compile(r'tests_profile[.]\S*[.]prof'),
-                         'tests_profile.*.prof'),
-                        ]),
-                    )
-                )
+            checker=renormalizing.RENormalizing([
+                (re.compile(r'tests_profile[.]\S*[.]prof'),
+                 'tests_profile.*.prof'),
+            ]),
+        )
+    )
+    try:
+        import cProfile
+        import pstats
+    except ImportError: # pragma: no cover (where is this true?)
+        pass
+    else:
+        suites.append(
+            doctest.DocFileSuite(
+                'testrunner-profiling-cprofiler.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=renormalizing.RENormalizing([
+                    (re.compile(r'tests_profile[.]\S*[.]prof'),
+                     'tests_profile.*.prof'),
+                ]),
+            )
+        )
 
     suites.append(
         doctest.DocFileSuite(
@@ -320,39 +310,36 @@ def test_suite():
     if hasattr(sys, 'gettotalrefcount'):
         suites.append(
             doctest.DocFileSuite(
-            'testrunner-leaks.txt',
-            setUp=setUp, tearDown=tearDown,
-            optionflags=optionflags,
-            checker = renormalizing.RENormalizing([
-              (re.compile(r'(\d+ minutes )?\d+[.]\d\d\d seconds'), 'N.NNN seconds'),
-              (re.compile(r'sys refcount=\d+ +change=\d+'),
-               'sys refcount=NNNNNN change=NN'),
-              (re.compile(r'sum detail refcount=\d+ +'),
-               'sum detail refcount=NNNNNN '),
-              (re.compile(r'total +\d+ +\d+'),
-               'total               NNNN    NNNN'),
-              (re.compile(r"^ +(int|type) +-?\d+ +-?\d+ *\n", re.M),
-               ''),
-              ]),
-
+                'testrunner-leaks.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=renormalizing.RENormalizing([
+                    (re.compile(r'(\d+ minutes )?\d+[.]\d\d\d seconds'), 'N.NNN seconds'),
+                    (re.compile(r'sys refcount=\d+ +change=\d+'),
+                     'sys refcount=NNNNNN change=NN'),
+                    (re.compile(r'sum detail refcount=\d+ +'),
+                     'sum detail refcount=NNNNNN '),
+                    (re.compile(r'total +\d+ +\d+'),
+                     'total               NNNN    NNNN'),
+                    (re.compile(r"^ +(int|type) +-?\d+ +-?\d+ *\n", re.M),
+                     ''),
+                ]),
             )
         )
     else:
         suites.append(
             doctest.DocFileSuite(
-            'testrunner-leaks-err.txt',
-            setUp=setUp, tearDown=tearDown,
-            optionflags=optionflags,
-            checker=checker,
+                'testrunner-leaks-err.txt',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker,
             )
         )
 
-    if sys.version_info[:3] >= (2,7,0):
-        # Python 2.7 adds support for unittest.expectedFailure
-        suites.append(doctest.DocFileSuite(
-            'testrunner-unexpected-success.txt',
-            setUp=setUp, tearDown=tearDown,
-            optionflags=optionflags,
-            checker=checker))
+    suites.append(doctest.DocFileSuite(
+        'testrunner-unexpected-success.txt',
+        setUp=setUp, tearDown=tearDown,
+        optionflags=optionflags,
+        checker=checker))
 
     return unittest.TestSuite(suites)

--- a/src/zope/testrunner/tests/testrunner-ex-pp-products/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-pp-products/sampletests.py
@@ -20,6 +20,7 @@ class Test(unittest.TestCase):
 
     def test_extra_test_in_products(self):
         pass
-        
+
+
 def test_suite():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-knit.txt
+++ b/src/zope/testrunner/tests/testrunner-knit.txt
@@ -18,7 +18,7 @@ It isn't enough to add the containing directory to the test path
 because then we wouldn't be able to determine the package name
 properly.  We might be able to use the --package option to run the
 tests from the sample4/products package, but we want to run tests in
-testrunner-ex that aren't in this package.  
+testrunner-ex that aren't in this package.
 
 We can use the --package-path option in this case.  The --package-path
 option is like the --test-path option in that it defines a path to be
@@ -39,7 +39,8 @@ package name and file path.
     ...     ]
 
     >>> from zope import testrunner
-    
+    >>> old_argv = sys.argv
+
     >>> sys.argv = 'test --layer Layer111 -vv'.split()
     >>> _ = testrunner.run_internal(defaults)
     Running tests at level 1
@@ -103,3 +104,6 @@ or individual packages within knit-in packages:
       Tear down samplelayers.Layer11 in 0.000 seconds.
       Tear down samplelayers.Layer1 in 0.000 seconds.
 
+Restore the arguments::
+
+    >>> sys.argv = old_argv

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ basepython =
 commands =
     coverage run setup.py -q test -q
     coverage combine
-    coverage report
+    coverage report --fail-under=85
 setenv =
     COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,23 @@
 [tox]
 envlist =
-    py27,pypy,py33,py34,py35,py36,pypy3
+    py27,pypy,py34,py35,py36,pypy3,coverage
 
 [testenv]
 deps =
-    zope.testing
+    .[test]
 commands =
     python setup.py -q test -q
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python3.6
+commands =
+    coverage run setup.py -q test -q
+    coverage combine
+    coverage report
+setenv =
+    COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
- tox.ini environment
- coveralls.io on Travis
- Add badge
- Drop Python 3.3
- Some low-hanging fruit for improved coverage: remove code that was only executed on 2.6 or lower