### PR TITLE
Add option to check for duplicate test IDs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@
 - Use ipdb instead of pdb for post-mortem debugging if available
   (`#10 <https://github.com/zopefoundation/zope.testrunner/issues/10>`_).
 
+- Add a --require-unique option to check for duplicate test IDs. See
+  `LP #682771
+  <https://bugs.launchpad.net/launchpad/+bug/682771>`_.
+
 4.8.1 (2017-11-12)
 ==================
 

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -450,7 +450,7 @@ def tests_from_suite(suite, options, dlevel=1,
         yield (suite, None)
     else:
         if options.require_unique_ids:
-            suite_id = suite.id()
+            suite_id = str(suite)
             if suite_id in seen_test_ids:
                 duplicated_test_ids.add(suite_id)
             else:

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -140,6 +140,14 @@ searching.add_argument(
     default=False,
     help="List all tests that matched your filters.  Do not run any tests.")
 
+searching.add_argument(
+    '--require-unique', action="store_true", dest='require_unique_ids',
+    default=False,
+    help="""\
+Require that all test IDs be unique and raise an error if duplicates are
+encountered.
+""")
+
 
 ######################################################################
 # Reporting
@@ -646,6 +654,15 @@ def get_options(args=None, defaults=None):
         """)
         options.fail = True
         return options
+
+    if options.module and options.require_unique_ids:
+        # We warn if --module and --require-unique are specified at the same
+        # time, though we don't exit.
+        print("""\
+        You specified a module along with --require-unique;
+        --require-unique will not try to enforce test ID uniqueness when
+        working with a specific module.
+        """)
 
     return options
 

--- a/src/zope/testrunner/tests/test_find.py
+++ b/src/zope/testrunner/tests/test_find.py
@@ -75,5 +75,5 @@ class TestUniqueness(unittest.TestCase):
         # contains all the duplicate test IDs it found.
         with self.assertRaises(find.DuplicateTestIDError) as e:
             find.find_tests(UniquenessOptions(), [self.test_suites])
-        self.assertIn('sampletests_rst', str(e.exception))
-        self.assertIn('sampletestsl_rst', str(e.exception))
+        self.assertIn('testrunner-ex/sampletests.rst', str(e.exception))
+        self.assertIn('testrunner-ex/sampletestsl.rst', str(e.exception))

--- a/src/zope/testrunner/tests/test_find.py
+++ b/src/zope/testrunner/tests/test_find.py
@@ -1,0 +1,79 @@
+##############################################################################
+#
+# Copyright (c) 2017 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Unit tests for test discovery."""
+
+import doctest
+import unittest
+
+from zope.testrunner import find
+
+
+class UniquenessOptions:
+    """A basic mock of our command-line options."""
+
+    keepbytecode = True
+    at_level = 99
+    test = []
+    module = []
+    require_unique_ids = True
+
+
+class TestUniqueness(unittest.TestCase):
+    """Test how the testrunner handles non-unique IDs."""
+
+    def setUp(self):
+        super(TestUniqueness, self).setUp()
+        suites = [
+            doctest.DocFileSuite('testrunner-ex/sampletests.rst'),
+            doctest.DocFileSuite('testrunner-ex/sampletests.rst'),
+            doctest.DocFileSuite('testrunner-ex/sampletestsl.rst'),
+            doctest.DocFileSuite('testrunner-ex/sampletestsl.rst'),
+            ]
+        self.test_suites = unittest.TestSuite(suites)
+
+    def test_tests_from_suite_records_duplicate_test_ids(self):
+        # If tests_from_suite encounters a test ID which has already been
+        # registered, it records them in the duplicated_test_ids set it is
+        # passed.
+        duplicated_test_ids = set()
+        list(find.tests_from_suite(
+            self.test_suites, UniquenessOptions(),
+            duplicated_test_ids=duplicated_test_ids))
+        self.assertNotEqual(0, len(duplicated_test_ids))
+
+    def test_tests_from_suite_ignores_duplicate_ids_if_option_not_set(self):
+        # If the require_unique_ids option is not set, tests_from_suite will
+        # not record any of the IDs as duplicates.
+        options = UniquenessOptions()
+        options.require_unique_ids = False
+        duplicated_test_ids = set()
+        list(find.tests_from_suite(
+            self.test_suites, options,
+            duplicated_test_ids=duplicated_test_ids))
+        self.assertEqual(0, len(duplicated_test_ids))
+
+    def test_find_tests_raises_error_if_duplicates_found(self):
+        # If find_tests, which calls tests_from_suite, finds a duplicate
+        # test ID, it raises an error.
+        self.assertRaises(
+            find.DuplicateTestIDError,
+            find.find_tests, UniquenessOptions(), [self.test_suites])
+
+    def test_DuplicateTestIDError_message_contains_all_test_ids(self):
+        # The error raised by find_tests when duplicates are encountered
+        # contains all the duplicate test IDs it found.
+        with self.assertRaises(find.DuplicateTestIDError) as e:
+            find.find_tests(UniquenessOptions(), [self.test_suites])
+        self.assertIn('sampletests_rst', str(e.exception))
+        self.assertIn('sampletestsl_rst', str(e.exception))

--- a/src/zope/testrunner/tests/test_find.py
+++ b/src/zope/testrunner/tests/test_find.py
@@ -14,6 +14,7 @@
 """Unit tests for test discovery."""
 
 import doctest
+import os.path
 import unittest
 
 from zope.testrunner import find
@@ -75,5 +76,8 @@ class TestUniqueness(unittest.TestCase):
         # contains all the duplicate test IDs it found.
         with self.assertRaises(find.DuplicateTestIDError) as e:
             find.find_tests(UniquenessOptions(), [self.test_suites])
-        self.assertIn('testrunner-ex/sampletests.rst', str(e.exception))
-        self.assertIn('testrunner-ex/sampletestsl.rst', str(e.exception))
+        self.assertIn(
+            os.path.join('testrunner-ex', 'sampletests.rst'), str(e.exception))
+        self.assertIn(
+            os.path.join('testrunner-ex', 'sampletestsl.rst'),
+            str(e.exception))


### PR DESCRIPTION
Add a --require-unique flag to the testrunner.  When passed, this flag
causes the testrunner to check every test ID it loads to see if it's
seen it before.  If it has, it raises an error and exits.

This was originally by Graham Binns in
https://code.launchpad.net/~gmb/zope.testing/check-for-unique-tests/+merge/110262,
in response to https://bugs.launchpad.net/launchpad/+bug/682771, but
doesn't appear to have been sent upstream.  I ported it across to
zope.testrunner and generally brought it up to date.