### PR TITLE
Use ipdb instead of pdb if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@
   ``optparse``. See `issue 61
   <https://github.com/zopefoundation/zope.testrunner/issues/61>`_.
 
+- Use ipdb instead of pdb for post-mortem debugging if available
+  (`#10 <https://github.com/zopefoundation/zope.testrunner/issues/10>`_).
+
 4.8.1 (2017-11-12)
 ==================
 


### PR DESCRIPTION
Fixes #10.

I couldn't figure out a way to write tests for this that didn't run into the fact that ipdb makes quite a few demands of `sys.stdin` that aren't satisfied by the fake `Input` class used by the tests (which is why #12 didn't work), but I've at least tested this manually in 2.7 and 3.5 virtualenvs with ipdb installed.