### PR TITLE
Refactor subprocess result output to emit bytes

### DIFF
--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -206,7 +206,9 @@ if sys.version_info[0] >= 3:
             # that a trailing newline is missing.
             if result and not result.endswith("\n"):
                 result += "\n"
-            return result.replace('\n', os.linesep)
+            # We're reading bytes, so we have to do universal newlines
+            # conversion by hand.
+            return result.replace(os.linesep, '\n')
 
         def truncate(self, size=None):
             self.seek(size)

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -15,13 +15,13 @@
 """
 from __future__ import print_function
 
-import re
+import doctest
 import gc
 import os
+import re
 import sys
 import unittest
 
-import doctest
 from zope.testing import renormalizing
 
 
@@ -178,6 +178,41 @@ else:
 
         ])
 
+
+# On Python 3, monkey-patch doctest with our own _SpoofOut replacement.  We
+# need sys.stdout to be binary-capable so that we can pass through binary
+# output from test formatters cleanly, which is in particular required for
+# subunit.  We don't expect to be able to do actual binary comparisons in
+# doctests, but that's OK.
+# See https://github.com/zopefoundation/zope.testrunner/pull/23 for the
+# background.
+if sys.version_info[0] >= 3:
+    import io
+
+    class _SpoofOut(io.TextIOWrapper):
+        def __init__(self):
+            super(_SpoofOut, self).__init__(io.BytesIO(), encoding='utf-8')
+
+        def write(self, s):
+            super(_SpoofOut, self).write(s)
+            # Always flush immediately so that getvalue() never returns
+            # short results.
+            self.flush()
+
+        def getvalue(self):
+            result = self.buffer.getvalue().decode('utf-8', 'replace')
+            # If anything at all was written, make sure there's a trailing
+            # newline.  There's no way for the expected output to indicate
+            # that a trailing newline is missing.
+            if result and not result.endswith("\n"):
+                result += "\n"
+            return result
+
+        def truncate(self, size=None):
+            self.seek(size)
+            super(_SpoofOut, self).truncate()
+
+
 def setUp(test):
     test.globs['print_function'] = print_function
     test.globs['saved-sys-info'] = (
@@ -187,6 +222,9 @@ def setUp(test):
     )
     if hasattr(gc, 'get_threshold'):
         test.globs['saved-gc-threshold'] = gc.get_threshold()
+    if sys.version_info[0] >= 3:
+        test.globs['saved-doctest-SpoofOut'] = doctest._SpoofOut
+        doctest._SpoofOut = _SpoofOut
     test.globs['this_directory'] = os.path.split(__file__)[0]
     test.globs['testrunner_script'] = sys.argv[0]
 
@@ -197,6 +235,8 @@ def tearDown(test):
         gc.set_threshold(*test.globs['saved-gc-threshold'])
     sys.modules.clear()
     sys.modules.update(test.globs['saved-sys-info'][2])
+    if sys.version_info[0] >= 3:
+        doctest._SpoofOut = test.globs['saved-doctest-SpoofOut']
 
 
 def test_suite():

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -206,7 +206,7 @@ if sys.version_info[0] >= 3:
             # that a trailing newline is missing.
             if result and not result.endswith("\n"):
                 result += "\n"
-            return result
+            return result.replace('\n', os.linesep)
 
         def truncate(self, size=None):
             self.seek(size)

--- a/src/zope/testrunner/tests/testrunner-layers-buff.rst
+++ b/src/zope/testrunner/tests/testrunner-layers-buff.rst
@@ -14,6 +14,10 @@ which a given line was written.
     ...         self.record = []
     ...         self.wrapped = wrapped
     ...     def write(self, out):
+    ...         # Not very accurate, but it will do as long as we don't
+    ...         # actually need to be binary-clean.
+    ...         if not isinstance(out, str):
+    ...             out = out.decode('utf-8')
     ...         self.record.append((out, datetime.datetime.now()))
     ...         self.wrapped.write(out)
     ...     def writelines(self, lines):


### PR DESCRIPTION
This fixes the underlying problems that led to test failures on Python 3
in #23, paving the way for the reintroduction of subunit support.  It
also generally makes more logical sense to emit bytes here, as can be
seen from the way that we no longer need to decode in the Python 3 case
only to have the stream encode again.

Doctests still need to work with text, but we can handle that by
monkey-patching a replacement for `doctest._SpoofOut` on Python 3 that
makes an underlying `io.BytesIO` available.  (This effectively takes the
run-time special cases for Python 3 and isolates them in the doctest
support code, which seems like an improvement.)

`_get_output_buffer` is a simplified version of `subunit._unwrap_text`,
incorporated here to allow consistent behaviour without a hard
dependency on subunit.