### PR TITLE
Reintroduce subunit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,14 @@ python:
   - 3.6
   - pypy
   - pypy3
-matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=py27-subunit
-    - python: pypy
-      env: TOXENV=pypy-subunit
+env:
+  - SUBUNIT=true
+  - SUBUNIT=false
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls
     - pip install -U -e .[test]
+    - [ "$SUBUNIT" != true ] || pip install -U -e .[subunit]
 script:
     - COVERAGE_PROCESS_START=`pwd`/.coveragerc coverage run setup.py -q test -q
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls
     - pip install -U -e .[test]
-    - [ "$SUBUNIT" != true ] || pip install -U -e .[subunit]
+    - test "$SUBUNIT" != true || pip install -U -e .[subunit]
 script:
     - COVERAGE_PROCESS_START=`pwd`/.coveragerc coverage run setup.py -q test -q
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
   - 3.6
   - pypy
   - pypy3
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-subunit
+    - python: pypy
+      env: TOXENV=pypy-subunit
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@
   `LP #682771
   <https://bugs.launchpad.net/launchpad/+bug/682771>`_.
 
+- Reintroduce optional support for ``subunit``, now with support for both
+  version 1 and version 2 of its protocol.
+
 4.8.1 (2017-11-12)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,14 @@ environment:
     - python: 36-x64
     - { python: 27, SUBUNIT: 1 }
     - { python: 27-x64, SUBUNIT: 1 }
+    - { python: 33, SUBUNIT: 1 }
+    - { python: 33-x64, SUBUNIT: 1 }
+    - { python: 34, SUBUNIT: 1 }
+    - { python: 34-x64, SUBUNIT: 1 }
+    - { python: 35, SUBUNIT: 1 }
+    - { python: 35-x64, SUBUNIT: 1 }
+    - { python: 36, SUBUNIT: 1 }
+    - { python: 36-x64, SUBUNIT: 1 }
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
@@ -20,7 +28,7 @@ install:
   - pip install -U setuptools
   # NB: pip install -e .[test] fails for obscure namespace package reasons
   - pip install -U .[test]
-  - ps: if($env:SUBUNIT -eq 1) { pip install python-subunit }
+  - ps: if($env:SUBUNIT -eq 1) { pip install -U .[subunit] }
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - { python: 27, SUBUNIT: 1 }
+    - { python: 27-x64, SUBUNIT: 1 }
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
@@ -18,6 +20,7 @@ install:
   - pip install -U setuptools
   # NB: pip install -e .[test] fails for obscure namespace package reasons
   - pip install -U .[test]
+  - ps: if($env:SUBUNIT -eq 1) { pip install python-subunit }
 
 build: false
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -136,9 +136,10 @@ Other features
 ==============
 
 zope.testrunner can profile your tests, measure test coverage,
-check for memory leaks, shuffle the test execution order, and run
-multiple tests in parallel.
+check for memory leaks, integrate with subunit_, shuffle the
+test execution order, and run multiple tests in parallel.
 
 .. _buildout: https://buildout.readthedocs.io
 .. _virtualenv: https://virtualenv.pypa.io/
 .. _zc.recipe.testrunner: https://pypi.python.org/pypi/zc.recipe.testrunner
+.. _subunit: http://pypi.python.org/pypi/subunit

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -142,4 +142,4 @@ test execution order, and run multiple tests in parallel.
 .. _buildout: https://buildout.readthedocs.io
 .. _virtualenv: https://virtualenv.pypa.io/
 .. _zc.recipe.testrunner: https://pypi.python.org/pypi/zc.recipe.testrunner
-.. _subunit: http://pypi.python.org/pypi/subunit
+.. _subunit: https://pypi.python.org/pypi/python-subunit

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ EXTRAS_REQUIRE = {
         'Sphinx',
         'sphinxcontrib-programoutput',
     ],
+    'subunit': TESTS_REQUIRE + ['python-subunit'],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,14 @@ TESTS_REQUIRE = [
 
 EXTRAS_REQUIRE = {
     'test': TESTS_REQUIRE,
+    'subunit': [
+        'python-subunit >= 0.0.11',
+        'testtools >= 0.9.30',
+    ],
     'docs': [
         'Sphinx',
         'sphinxcontrib-programoutput',
     ],
-    'subunit': TESTS_REQUIRE + ['python-subunit'],
 }
 
 

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -924,7 +924,7 @@ class SubunitOutputFormatter(object):
 
     def profiler_stats(self, stats):
         """Report profiler stats."""
-        fd, filename = tempfile.mkstemp()
+        fd, filename = tempfile.mkstemp(prefix='zope.testrunner-')
         os.close(fd)
         try:
             stats.dump_stats(filename)

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -1236,7 +1236,7 @@ class SubunitV2OutputFormatter(SubunitOutputFormatter):
         # XXX: Mostly used for user errors, sometimes used for errors in the
         # test framework, sometimes used to record layer setUp failure (!!!).
         self._subunit.status(
-            file_name='error', file_bytes=str(message).encode('utf-8'),
+            file_name='error', file_bytes=unicode(message).encode('utf-8'),
             eof=True, mime_type=repr(self.PLAIN_TEXT))
 
     def _emit_exists(self, test):

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -1038,7 +1038,7 @@ class SubunitOutputFormatter(object):
         self._subunit.startTest(test)
         self._subunit.tags([self.TAG_THREADS], [])
         self._subunit.addError(
-            test, details={'garbage': text_content(unicode(new_threads))})
+            test, details={'threads': text_content(unicode(new_threads))})
         self._subunit.stopTest(test)
 
     def refcounts(self, rc, prev):

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -15,10 +15,11 @@
 """
 from __future__ import print_function
 
+from contextlib import contextmanager
 import doctest
 import os
-import sys
 import re
+import sys
 import tempfile
 import traceback
 
@@ -734,38 +735,77 @@ class FakeTest(object):
         return self._id
 
 
-# Conditional imports, we don't want zope.testrunner to have a hard dependency on
-# subunit.
+# Conditional imports: we don't want zope.testrunner to have a hard
+# dependency on subunit.
 try:
     import subunit
     from subunit.iso8601 import Utc
-except ImportError:
+    subunit.StreamResultToBytes
+except (ImportError, AttributeError):
     subunit = None
 
 
-# testtools is a hard dependency of subunit itself, guarding separately for
-# richer error messages.
+# testtools is a hard dependency of subunit itself, but we guard it
+# separately for richer error messages.
 try:
-    from testtools import content
-except ImportError:
-    content = None
+    import testtools
+    from testtools.content import (
+        Content,
+        ContentType,
+        content_from_file,
+        text_content,
+    )
+    testtools.StreamToExtendedDecorator
+except (ImportError, AttributeError):
+    testtools = None
+
+
+class _RunnableDecorator(object):
+    """Permit controlling the runnable annotation on tests.
+
+    This decorates a StreamResult, adding a setRunnable context manager to
+    indicate whether a test is runnable.  (A context manager is unidiomatic
+    here, but it's just about the simplest way to stuff the relevant state
+    through the various layers of decorators involved without accidentally
+    affecting later test results.)
+    """
+
+    def __init__(self, decorated):
+        self.decorated = decorated
+        self._runnable = True
+
+    def __getattr__(self, name):
+        return getattr(self.decorated, name)
+
+    @contextmanager
+    def setRunnable(self, runnable):
+        orig_runnable = self._runnable
+        try:
+            self._runnable = runnable
+            yield
+        finally:
+            self._runnable = orig_runnable
+
+    def status(self, **kwargs):
+        kwargs = dict(kwargs)
+        kwargs['runnable'] = self._runnable
+        self.decorated.status(**kwargs)
 
 
 class SubunitOutputFormatter(object):
     """A subunit output formatter.
 
-    This output formatter generates subunit compatible output (see
-    https://launchpad.net/subunit). Subunit output is essentially a stream of
-    results of unit tests. In this formatter, non-test events (such as layer
-    set up) are encoded as specially tagged tests and summary-generating
-    methods (such as modules_with_import_problems) deliberately do nothing.
+    This output formatter generates subunit-compatible output (see
+    https://launchpad.net/subunit).  Subunit output is essentially a stream
+    of results of unit tests.
 
-    In particular, for a layer 'foo', the fake tests related to layer set up
-    and tear down are tagged with 'zope:layer' and are called 'foo:setUp' and
-    'foo:tearDown'. Any tests within layer 'foo' are tagged with
-    'zope:layer:foo'.
+    In this formatter, non-test events (such as layer set up) are encoded as
+    specially-tagged tests.  In particular, for a layer 'foo', the fake
+    tests related to layer setup and teardown are tagged with 'zope:layer'
+    and are called 'foo:setUp' and 'foo:tearDown'.  Any tests within layer
+    'foo' are tagged with 'zope:layer:foo'.
 
-    Note that all tags specific to this formatter begin with 'zope:'
+    Note that all tags specific to this formatter begin with 'zope:'.
     """
 
     # subunit output is designed for computers, so displaying a progress bar
@@ -784,27 +824,31 @@ class SubunitOutputFormatter(object):
 
     def __init__(self, options, stream=None):
         if subunit is None:
-            raise Exception("Requires subunit 0.0.5 or better")
-        if content is None:
-            raise Exception("Requires testtools 0.9.2 or better")
+            raise Exception('Requires subunit 0.0.11 or better')
+        if testtools is None:
+            raise Exception('Requires testtools 0.9.30 or better')
         self.options = options
 
         if stream is None:
             stream = sys.stdout
         self._stream = stream
-        self._subunit = subunit.TestProtocolClient(self._stream)
+        self._subunit = self._subunit_factory(self._stream)
 
         # Used to track the last layer that was set up or torn down. Either
         # None or (layer_name, last_touched_time).
         self._last_layer = None
         self.UTC = Utc()
         # Content types used in the output.
-        self.TRACEBACK_CONTENT_TYPE = content.ContentType(
-            'text', 'x-traceback', dict(language='python', charset='utf8'))
-        self.PROFILE_CONTENT_TYPE = content.ContentType(
+        self.TRACEBACK_CONTENT_TYPE = ContentType(
+            'text', 'x-traceback', {'language': 'python', 'charset': 'utf8'})
+        self.PROFILE_CONTENT_TYPE = ContentType(
             'application', 'x-binary-profile')
-        self.PLAIN_TEXT = content.ContentType(
-            'text', 'plain', {'charset': 'utf8'})
+        self.PLAIN_TEXT = ContentType('text', 'plain', {'charset': 'utf8'})
+
+    @classmethod
+    def _subunit_factory(cls, stream):
+        """Return a TestResult attached to the given stream."""
+        return _RunnableDecorator(subunit.TestProtocolClient(stream))
 
     def _emit_timestamp(self, now=None):
         """Emit a timestamp to the subunit stream.
@@ -816,39 +860,45 @@ class SubunitOutputFormatter(object):
         self._subunit.time(now)
         return now
 
-    def _emit_tag(self, tag):
-        self._stream.write('tags: %s\n' % (tag,))
-
-    def _stop_tag(self, tag):
-        self._stream.write('tags: -%s\n' % (tag,))
-
     def _emit_fake_test(self, message, tag, details=None):
         """Emit a successful fake test to the subunit stream.
 
         Use this to print tagged informative messages.
         """
         test = FakeTest(message)
-        self._subunit.startTest(test)
-        self._emit_tag(tag)
-        self._subunit.addSuccess(test, details=details)
+        with self._subunit.setRunnable(False):
+            self._subunit.startTest(test)
+            self._subunit.tags([tag], [])
+            self._subunit.addSuccess(test, details=details)
+            self._subunit.stopTest(test)
 
-    def _emit_error(self, error_id, tag, exc_info):
+    def _emit_error(self, error_id, tag, exc_info, runnable=False):
         """Emit an error to the subunit stream.
 
         Use this to pass on information about errors that occur outside of
         tests.
         """
         test = FakeTest(error_id)
-        self._subunit.startTest(test)
-        self._emit_tag(tag)
-        self._subunit.addError(test, exc_info)
+        with self._subunit.setRunnable(runnable):
+            self._subunit.startTest(test)
+            self._subunit.tags([tag], [])
+            self._subunit.addError(test, exc_info)
+            self._subunit.stopTest(test)
+
+    def _enter_layer(self, layer_name):
+        """Tell subunit that we are entering a layer."""
+        self._subunit.tags(['zope:layer:%s' % (layer_name,)], [])
+
+    def _exit_layer(self, layer_name):
+        """Tell subunit that we are exiting a layer."""
+        self._subunit.tags([], ['zope:layer:%s' % (layer_name,)])
 
     def info(self, message):
-        """Print an informative message, but only if verbose."""
-        # info() output is not relevant to actual test results. It only says
-        # things like "Running tests" or "Tearing down left over layers",
-        # things that are communicated already by the subunit stream. Just
-        # suppress the info() output.
+        """Print an informative message."""
+        # info() output is not relevant to actual test results.  It only
+        # says things like "Running tests" or "Tearing down left over
+        # layers", things that are communicated already by the subunit
+        # stream.  Just suppress the info() output.
         pass
 
     def info_suboptimal(self, message):
@@ -872,47 +922,203 @@ class SubunitOutputFormatter(object):
         # Or "Can't post-mortem debug when running a layer as a subprocess!"
         self._emit_fake_test(message, self.TAG_ERROR_WITH_BANNER)
 
-    def _enter_layer(self, layer_name):
-        """Signal in the subunit stream that we are entering a layer."""
-        self._emit_tag('zope:layer:%s' % (layer_name,))
+    def profiler_stats(self, stats):
+        """Report profiler stats."""
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            stats.dump_stats(filename)
+            profile_content = content_from_file(
+                filename, content_type=self.PROFILE_CONTENT_TYPE)
+            details = {'profiler-stats': profile_content}
+            # Name the test 'zope:profiler_stats' just like its tag.
+            self._emit_fake_test(
+                self.TAG_PROFILER_STATS, self.TAG_PROFILER_STATS, details)
+        finally:
+            os.unlink(filename)
 
-    def _exit_layer(self, layer_name):
-        """Signal in the subunit stream that we are leaving a layer."""
-        self._stop_tag('zope:layer:%s' % (layer_name,))
+    def import_errors(self, import_errors):
+        """Report test-module import errors (if any)."""
+        if import_errors:
+            for error in import_errors:
+                self._emit_error(
+                    error.module, self.TAG_IMPORT_ERROR, error.exc_info,
+                    runnable=True)
+
+    def tests_with_errors(self, errors):
+        """Report names of tests with errors (if any).
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def tests_with_failures(self, failures):
+        """Report names of tests with failures (if any).
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def modules_with_import_problems(self, import_errors):
+        """Report names of modules with import problems (if any)."""
+        # This is simply a summary method, and subunit output doesn't
+        # benefit from summaries.
+        pass
+
+    def summary(self, n_tests, n_failures, n_errors, n_seconds,
+                n_skipped=0):
+        """Summarize the results of a single test layer.
+
+        Since subunit is a stream protocol format, it has no need for a
+        summary. When the stream is finished other tools can generate a
+        summary if so desired.
+        """
+        pass
+
+    def totals(self, n_tests, n_failures, n_errors, n_seconds, n_skipped=0):
+        """Summarize the results of all layers.
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def _emit_exists(self, test):
+        """Emit an indication that a test exists.
+
+        With the v1 protocol, we just emit a fake success line.
+        """
+        self._subunit.addSuccess(test)
+
+    def list_of_tests(self, tests, layer_name):
+        """Report a list of test names."""
+        self._enter_layer(layer_name)
+        for test in tests:
+            self._subunit.startTest(test)
+            self._emit_exists(test)
+            self._subunit.stopTest(test)
+        self._exit_layer(layer_name)
+
+    def garbage(self, garbage):
+        """Report garbage generated by tests."""
+        # XXX: Really, 'garbage', 'profiler_stats' and the 'refcounts' twins
+        # ought to add extra details to a fake test that represents the
+        # summary information for the whole suite. However, there's no event
+        # on output formatters for "everything is really finished, honest". --
+        # jml, 2010-02-14
+        details = {'garbage': text_content(unicode(garbage))}
+        self._emit_fake_test(self.TAG_GARBAGE, self.TAG_GARBAGE, details)
+
+    def test_garbage(self, test, garbage):
+        """Report garbage generated by a test.
+
+        Encoded in the subunit stream as a test error.  Clients can filter
+        out these tests based on the tag if they don't think garbage should
+        fail the test run.
+        """
+        # XXX: Perhaps 'test_garbage' and 'test_threads' ought to be within
+        # the output for the actual test, appended as details to whatever
+        # result the test gets. Not an option with the present API, as there's
+        # no event for "no more output for this test". -- jml, 2010-02-14
+        self._subunit.startTest(test)
+        self._subunit.tags([self.TAG_GARBAGE], [])
+        self._subunit.addError(
+            test, details={'garbage': text_content(unicode(garbage))})
+        self._subunit.stopTest(test)
+
+    def test_threads(self, test, new_threads):
+        """Report threads left behind by a test.
+
+        Encoded in the subunit stream as a test error.  Clients can filter
+        out these tests based on the tag if they don't think left-over
+        threads should fail the test run.
+        """
+        self._subunit.startTest(test)
+        self._subunit.tags([self.TAG_THREADS], [])
+        self._subunit.addError(
+            test, details={'garbage': text_content(unicode(new_threads))})
+        self._subunit.stopTest(test)
+
+    def refcounts(self, rc, prev):
+        """Report a change in reference counts."""
+        details = {
+            'sys-refcounts': text_content(str(rc)),
+            'changes': text_content(str(rc - prev)),
+        }
+        # XXX: Emit the details dict as JSON?
+        self._emit_fake_test(self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
+
+    def detailed_refcounts(self, track, rc, prev):
+        """Report a change in reference counts, with extra detail."""
+        details = {
+            'sys-refcounts': text_content(str(rc)),
+            'changes': text_content(str(rc - prev)),
+            'track': text_content(str(track.delta)),
+        }
+        self._emit_fake_test(self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
 
     def start_set_up(self, layer_name):
         """Report that we're setting up a layer.
 
-        We do this by emitting a tag of the form 'layer:$LAYER_NAME'.
+        We do this by emitting a fake test of the form '$LAYER_NAME:setUp'
+        and adding a tag of the form 'zope:layer:$LAYER_NAME' to the current
+        tag context.
+
+        The next output operation should be stop_set_up().
         """
+        test = FakeTest('%s:setUp' % (layer_name,))
         now = self._emit_timestamp()
-        self._subunit.startTest(FakeTest('%s:setUp' % (layer_name,)))
-        self._emit_tag(self.TAG_LAYER)
+        with self._subunit.setRunnable(False):
+            self._subunit.startTest(test)
+            self._subunit.tags([self.TAG_LAYER], [])
         self._last_layer = (layer_name, now)
 
     def stop_set_up(self, seconds):
+        """Report that we've set up a layer.
+
+        Should be called right after start_set_up().
+        """
         layer_name, start_time = self._last_layer
         self._last_layer = None
+        test = FakeTest('%s:setUp' % (layer_name,))
         self._emit_timestamp(start_time + timedelta(seconds=seconds))
-        self._subunit.addSuccess(FakeTest('%s:setUp' % (layer_name,)))
+        with self._subunit.setRunnable(False):
+            self._subunit.addSuccess(test)
+            self._subunit.stopTest(test)
         self._enter_layer(layer_name)
 
     def start_tear_down(self, layer_name):
         """Report that we're tearing down a layer.
 
-        We do this by removing a tag of the form 'layer:$LAYER_NAME'.
+        We do this by emitting a fake test of the form
+        '$LAYER_NAME:tearDown' and removing a tag of the form
+        'layer:$LAYER_NAME' from the current tag context.
+
+        The next output operation should be stop_tear_down() or
+        tear_down_not_supported().
         """
+        test = FakeTest('%s:tearDown' % (layer_name,))
         self._exit_layer(layer_name)
         now = self._emit_timestamp()
-        self._subunit.startTest(FakeTest('%s:tearDown' % (layer_name,)))
-        self._emit_tag(self.TAG_LAYER)
+        with self._subunit.setRunnable(False):
+            self._subunit.startTest(test)
+            self._subunit.tags([self.TAG_LAYER], [])
         self._last_layer = (layer_name, now)
 
     def stop_tear_down(self, seconds):
+        """Report that we've torn down a layer.
+
+        Should be called right after start_tear_down().
+        """
         layer_name, start_time = self._last_layer
         self._last_layer = None
+        test = FakeTest('%s:tearDown' % (layer_name,))
         self._emit_timestamp(start_time + timedelta(seconds=seconds))
-        self._subunit.addSuccess(FakeTest('%s:tearDown' % (layer_name,)))
+        with self._subunit.setRunnable(False):
+            self._subunit.addSuccess(test)
+            self._subunit.stopTest(test)
 
     def tear_down_not_supported(self):
         """Report that we could not tear down a layer.
@@ -921,19 +1127,11 @@ class SubunitOutputFormatter(object):
         """
         layer_name, start_time = self._last_layer
         self._last_layer = None
-        self._emit_timestamp(datetime.now(self.UTC))
-        self._subunit.addSkip(
-            FakeTest('%s:tearDown' % (layer_name,)), "tearDown not supported")
-
-    def summary(self, n_tests, n_failures, n_errors, n_seconds,
-                n_skipped=0):
-        """Print out a summary.
-
-        Since subunit is a stream protocol format, it has no need for a
-        summary. When the stream is finished other tools can generate a
-        summary if so desired.
-        """
-        pass
+        test = FakeTest('%s:tearDown' % (layer_name,))
+        self._emit_timestamp()
+        with self._subunit.setRunnable(False):
+            self._subunit.addSkip(test, 'tearDown not supported')
+            self._subunit.stopTest(test)
 
     def start_test(self, test, tests_run, total_tests):
         """Report that we're about to run a test.
@@ -942,61 +1140,51 @@ class SubunitOutputFormatter(object):
         test_failure().
         """
         self._emit_timestamp()
-        # Note that this always emits newlines, so it will function as well as
-        # other start_test implementations if we are running in a subprocess.
         self._subunit.startTest(test)
 
-    def stop_test(self, test):
-        """Clean up the output state after a test."""
-        self._subunit.stopTest(test)
-        self._stream.flush()
-
-    def stop_tests(self):
-        """Clean up the output state after a collection of tests."""
-        self._stream.flush()
-
     def test_success(self, test, seconds):
+        """Report that a test was successful.
+
+        Should be called right after start_test().
+
+        The next output operation should be stop_test().
+        """
         self._emit_timestamp()
         self._subunit.addSuccess(test)
 
     def test_skipped(self, test, reason):
+        """Report that a test was skipped.
+
+        Should be called right after start_test().
+
+        The next output operation should be stop_test().
+        """
         self._subunit.addSkip(test, reason)
 
-    def import_errors(self, import_errors):
-        """Report test-module import errors (if any)."""
-        if not import_errors:
-            return
-        for error in import_errors:
-            self._emit_error(
-                error.module, self.TAG_IMPORT_ERROR, error.exc_info)
-
-    def modules_with_import_problems(self, import_errors):
-        """Report names of modules with import problems (if any)."""
-        # This is simply a summary method, and subunit output doesn't benefit
-        # from summaries.
-        pass
-
     def _exc_info_to_details(self, exc_info):
-        """Translate 'exc_info' into a details dictionary usable with subunit.
-        """
-        # In an ideal world, we'd use the pre-bundled 'TracebackContent' class
-        # from testtools. However, 'OutputFormatter' contains special logic to
-        # handle errors from doctests, so we have to use that and manually
-        # create an object equivalent to an instance of 'TracebackContent'.
+        """Translate 'exc_info' into a details dict usable with subunit."""
+        # In an ideal world, we'd use the pre-bundled 'TracebackContent'
+        # class from testtools.  However, 'OutputFormatter' contains special
+        # logic to handle errors from doctests, so we have to use that and
+        # manually create an object equivalent to an instance of
+        # 'TracebackContent'.
         formatter = OutputFormatter(None)
         traceback = formatter.format_traceback(exc_info)
 
-        # We have no idea if the traceback is a unicode object or a bytestring
-        # with non-ASCII characters.  We had best be careful when handling it.
-        if isinstance(traceback, unicode):
-            unicode_tb = traceback
+        # We have no idea if the traceback is a unicode object or a
+        # bytestring with non-ASCII characters.  We had best be careful when
+        # handling it.
+        if isinstance(traceback, bytes):
+            # Assume the traceback was UTF-8-encoded, but still be careful.
+            unicode_tb = traceback.decode('utf-8', 'replace')
         else:
-            # Assume the traceback was utf-8 encoded, but still be careful.
-            unicode_tb = traceback.decode('utf8', 'replace')
+            unicode_tb = traceback
 
         return {
-            'traceback': content.Content(
-                self.TRACEBACK_CONTENT_TYPE, lambda: [unicode_tb.encode('utf8')])}
+            'traceback': Content(
+                self.TRACEBACK_CONTENT_TYPE,
+                lambda: [unicode_tb.encode('utf8')]),
+        }
 
     def test_error(self, test, seconds, exc_info):
         """Report that an error occurred while running a test.
@@ -1020,118 +1208,40 @@ class SubunitOutputFormatter(object):
         details = self._exc_info_to_details(exc_info)
         self._subunit.addFailure(test, details=details)
 
-    def profiler_stats(self, stats):
-        """Report profiler stats."""
-        fd, filename = tempfile.mkstemp()
-        os.close(fd)
-        try:
-            stats.dump_stats(filename)
-            stats_dump = open(filename)
-            try:
-                profile_content = content.Content(
-                    self.PROFILE_CONTENT_TYPE, stats_dump.read)
-                details = {'profiler-stats': profile_content}
-                # Name the test 'zope:profiler_stats' just like its tag.
-                self._emit_fake_test(
-                    self.TAG_PROFILER_STATS, self.TAG_PROFILER_STATS, details)
-            finally:
-                stats_dump.close()
-        finally:
-            os.unlink(filename)
+    def stop_test(self, test):
+        """Clean up the output state after a test."""
+        self._subunit.stopTest(test)
 
-    def tests_with_errors(self, errors):
-        """Report tests with errors.
-
-        Simply not supported by the subunit formatter. Fancy summary output
-        doesn't make sense.
-        """
+    def stop_tests(self):
+        """Clean up the output state after a collection of tests."""
+        # subunit handles all of this itself.
         pass
 
-    def tests_with_failures(self, failures):
-        """Report tests with failures.
 
-        Simply not supported by the subunit formatter. Fancy summary output
-        doesn't make sense.
-        """
-        pass
+class SubunitV2OutputFormatter(SubunitOutputFormatter):
+    """A subunit v2 output formatter."""
 
-    def totals(self, n_tests, n_failures, n_errors, n_seconds, n_skipped=0):
-        """Summarize the results of all layers.
+    @classmethod
+    def _subunit_factory(cls, stream):
+        """Return a TestResult attached to the given stream."""
+        stream_result = _RunnableDecorator(subunit.StreamResultToBytes(stream))
+        result = testtools.ExtendedToStreamDecorator(stream_result)
+        # Lift our decorating method up so that we can get at it easily.
+        result.setRunnable = stream_result.setRunnable
+        result.startTestRun()
+        return result
 
-        Simply not supported by the subunit formatter. Fancy summary output
-        doesn't make sense.
-        """
-        pass
+    def error(self, message):
+        """Report an error."""
+        # XXX: Mostly used for user errors, sometimes used for errors in the
+        # test framework, sometimes used to record layer setUp failure (!!!).
+        self._subunit.status(
+            file_name='error', file_bytes=str(message).encode('utf-8'),
+            eof=True, mime_type=repr(self.PLAIN_TEXT))
 
-    def list_of_tests(self, tests, layer_name):
-        """Report a list of test names."""
-        self._enter_layer(layer_name)
-        for test in tests:
-            self._subunit.startTest(test)
-            self._subunit.addSuccess(test)
-        self._exit_layer(layer_name)
-
-    def _get_text_details(self, name, text):
-        """Get a details dictionary that just has some plain text."""
-        return {
-            name: content.Content(
-                self.PLAIN_TEXT, lambda: [text.encode('utf8')])}
-
-    def garbage(self, garbage):
-        """Report garbage generated by tests."""
-        # XXX: Really, 'garbage', 'profiler_stats' and the 'refcounts' twins
-        # ought to add extra details to a fake test that represents the
-        # summary information for the whole suite. However, there's no event
-        # on output formatters for "everything is really finished, honest". --
-        # jml, 2010-02-14
-        details = self._get_text_details('garbage', unicode(garbage))
-        self._emit_fake_test(
-            self.TAG_GARBAGE, self.TAG_GARBAGE, details)
-
-    def test_garbage(self, test, garbage):
-        """Report garbage generated by a test.
-
-        Encoded in the subunit stream as a test error. Clients can filter out
-        these tests based on the tag if they don't think garbage should fail
-        the test run.
-        """
-        # XXX: Perhaps 'test_garbage' and 'test_threads' ought to be within
-        # the output for the actual test, appended as details to whatever
-        # result the test gets. Not an option with the present API, as there's
-        # no event for "no more output for this test". -- jml, 2010-02-14
-        self._subunit.startTest(test)
-        self._emit_tag(self.TAG_GARBAGE)
-        self._subunit.addError(
-            test, details=self._get_text_details('garbage', unicode(garbage)))
-
-    def test_threads(self, test, new_threads):
-        """Report threads left behind by a test.
-
-        Encoded in the subunit stream as a test error. Clients can filter out
-        these tests based on the tag if they don't think left-over threads
-        should fail the test run.
-        """
-        self._subunit.startTest(test)
-        self._emit_tag(self.TAG_THREADS)
-        self._subunit.addError(
-            test, details=self._get_text_details('garbage', unicode(new_threads)))
-
-    def refcounts(self, rc, prev):
-        """Report a change in reference counts."""
-        details = self._get_text_details('sys-refcounts', str(rc))
-        details.update(
-            self._get_text_details('changes', str(rc - prev)))
-        # XXX: Emit the details dict as JSON?
-        self._emit_fake_test(
-            self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
-
-    def detailed_refcounts(self, track, rc, prev):
-        """Report a change in reference counts, with extra detail."""
-        details = self._get_text_details('sys-refcounts', str(rc))
-        details.update(
-            self._get_text_details('changes', str(rc - prev)))
-        details.update(
-            self._get_text_details('track', str(track.delta)))
-
-        self._emit_fake_test(
-            self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
+    def _emit_exists(self, test):
+        """Emit an indication that a test exists."""
+        now = datetime.now(self.UTC)
+        self._subunit.status(
+            test_id=test.id(), test_status='exists',
+            test_tags=self._subunit.current_tags, timestamp=now)

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -732,3 +732,406 @@ class FakeTest(object):
 
     def id(self):
         return self._id
+
+
+# Conditional imports, we don't want zope.testrunner to have a hard dependency on
+# subunit.
+try:
+    import subunit
+    from subunit.iso8601 import Utc
+except ImportError:
+    subunit = None
+
+
+# testtools is a hard dependency of subunit itself, guarding separately for
+# richer error messages.
+try:
+    from testtools import content
+except ImportError:
+    content = None
+
+
+class SubunitOutputFormatter(object):
+    """A subunit output formatter.
+
+    This output formatter generates subunit compatible output (see
+    https://launchpad.net/subunit). Subunit output is essentially a stream of
+    results of unit tests. In this formatter, non-test events (such as layer
+    set up) are encoded as specially tagged tests and summary-generating
+    methods (such as modules_with_import_problems) deliberately do nothing.
+
+    In particular, for a layer 'foo', the fake tests related to layer set up
+    and tear down are tagged with 'zope:layer' and are called 'foo:setUp' and
+    'foo:tearDown'. Any tests within layer 'foo' are tagged with
+    'zope:layer:foo'.
+
+    Note that all tags specific to this formatter begin with 'zope:'
+    """
+
+    # subunit output is designed for computers, so displaying a progress bar
+    # isn't helpful.
+    progress = False
+    verbose = property(lambda self: self.options.verbose)
+
+    TAG_INFO_SUBOPTIMAL = 'zope:info_suboptimal'
+    TAG_ERROR_WITH_BANNER = 'zope:error_with_banner'
+    TAG_LAYER = 'zope:layer'
+    TAG_IMPORT_ERROR = 'zope:import_error'
+    TAG_PROFILER_STATS = 'zope:profiler_stats'
+    TAG_GARBAGE = 'zope:garbage'
+    TAG_THREADS = 'zope:threads'
+    TAG_REFCOUNTS = 'zope:refcounts'
+
+    def __init__(self, options, stream=None):
+        if subunit is None:
+            raise Exception("Requires subunit 0.0.5 or better")
+        if content is None:
+            raise Exception("Requires testtools 0.9.2 or better")
+        self.options = options
+
+        if stream is None:
+            stream = sys.stdout
+        self._stream = stream
+        self._subunit = subunit.TestProtocolClient(self._stream)
+
+        # Used to track the last layer that was set up or torn down. Either
+        # None or (layer_name, last_touched_time).
+        self._last_layer = None
+        self.UTC = Utc()
+        # Content types used in the output.
+        self.TRACEBACK_CONTENT_TYPE = content.ContentType(
+            'text', 'x-traceback', dict(language='python', charset='utf8'))
+        self.PROFILE_CONTENT_TYPE = content.ContentType(
+            'application', 'x-binary-profile')
+        self.PLAIN_TEXT = content.ContentType(
+            'text', 'plain', {'charset': 'utf8'})
+
+    def _emit_timestamp(self, now=None):
+        """Emit a timestamp to the subunit stream.
+
+        If 'now' is not specified, use the current time on the system clock.
+        """
+        if now is None:
+            now = datetime.now(self.UTC)
+        self._subunit.time(now)
+        return now
+
+    def _emit_tag(self, tag):
+        self._stream.write('tags: %s\n' % (tag,))
+
+    def _stop_tag(self, tag):
+        self._stream.write('tags: -%s\n' % (tag,))
+
+    def _emit_fake_test(self, message, tag, details=None):
+        """Emit a successful fake test to the subunit stream.
+
+        Use this to print tagged informative messages.
+        """
+        test = FakeTest(message)
+        self._subunit.startTest(test)
+        self._emit_tag(tag)
+        self._subunit.addSuccess(test, details=details)
+
+    def _emit_error(self, error_id, tag, exc_info):
+        """Emit an error to the subunit stream.
+
+        Use this to pass on information about errors that occur outside of
+        tests.
+        """
+        test = FakeTest(error_id)
+        self._subunit.startTest(test)
+        self._emit_tag(tag)
+        self._subunit.addError(test, exc_info)
+
+    def info(self, message):
+        """Print an informative message, but only if verbose."""
+        # info() output is not relevant to actual test results. It only says
+        # things like "Running tests" or "Tearing down left over layers",
+        # things that are communicated already by the subunit stream. Just
+        # suppress the info() output.
+        pass
+
+    def info_suboptimal(self, message):
+        """Print an informative message about losing some of the features.
+
+        For example, when you run some tests in a subprocess, you lose the
+        ability to use the debugger.
+        """
+        # Used _only_ to indicate running in a subprocess.
+        self._emit_fake_test(message.strip(), self.TAG_INFO_SUBOPTIMAL)
+
+    def error(self, message):
+        """Report an error."""
+        # XXX: Mostly used for user errors, sometimes used for errors in the
+        # test framework, sometimes used to record layer setUp failure (!!!).
+        self._stream.write('%s\n' % (message,))
+
+    def error_with_banner(self, message):
+        """Report an error with a big ASCII banner."""
+        # Either "Could not communicate with subprocess"
+        # Or "Can't post-mortem debug when running a layer as a subprocess!"
+        self._emit_fake_test(message, self.TAG_ERROR_WITH_BANNER)
+
+    def _enter_layer(self, layer_name):
+        """Signal in the subunit stream that we are entering a layer."""
+        self._emit_tag('zope:layer:%s' % (layer_name,))
+
+    def _exit_layer(self, layer_name):
+        """Signal in the subunit stream that we are leaving a layer."""
+        self._stop_tag('zope:layer:%s' % (layer_name,))
+
+    def start_set_up(self, layer_name):
+        """Report that we're setting up a layer.
+
+        We do this by emitting a tag of the form 'layer:$LAYER_NAME'.
+        """
+        now = self._emit_timestamp()
+        self._subunit.startTest(FakeTest('%s:setUp' % (layer_name,)))
+        self._emit_tag(self.TAG_LAYER)
+        self._last_layer = (layer_name, now)
+
+    def stop_set_up(self, seconds):
+        layer_name, start_time = self._last_layer
+        self._last_layer = None
+        self._emit_timestamp(start_time + timedelta(seconds=seconds))
+        self._subunit.addSuccess(FakeTest('%s:setUp' % (layer_name,)))
+        self._enter_layer(layer_name)
+
+    def start_tear_down(self, layer_name):
+        """Report that we're tearing down a layer.
+
+        We do this by removing a tag of the form 'layer:$LAYER_NAME'.
+        """
+        self._exit_layer(layer_name)
+        now = self._emit_timestamp()
+        self._subunit.startTest(FakeTest('%s:tearDown' % (layer_name,)))
+        self._emit_tag(self.TAG_LAYER)
+        self._last_layer = (layer_name, now)
+
+    def stop_tear_down(self, seconds):
+        layer_name, start_time = self._last_layer
+        self._last_layer = None
+        self._emit_timestamp(start_time + timedelta(seconds=seconds))
+        self._subunit.addSuccess(FakeTest('%s:tearDown' % (layer_name,)))
+
+    def tear_down_not_supported(self):
+        """Report that we could not tear down a layer.
+
+        Should be called right after start_tear_down().
+        """
+        layer_name, start_time = self._last_layer
+        self._last_layer = None
+        self._emit_timestamp(datetime.now(self.UTC))
+        self._subunit.addSkip(
+            FakeTest('%s:tearDown' % (layer_name,)), "tearDown not supported")
+
+    def summary(self, n_tests, n_failures, n_errors, n_seconds,
+                n_skipped=0):
+        """Print out a summary.
+
+        Since subunit is a stream protocol format, it has no need for a
+        summary. When the stream is finished other tools can generate a
+        summary if so desired.
+        """
+        pass
+
+    def start_test(self, test, tests_run, total_tests):
+        """Report that we're about to run a test.
+
+        The next output operation should be test_success(), test_error(), or
+        test_failure().
+        """
+        self._emit_timestamp()
+        # Note that this always emits newlines, so it will function as well as
+        # other start_test implementations if we are running in a subprocess.
+        self._subunit.startTest(test)
+
+    def stop_test(self, test):
+        """Clean up the output state after a test."""
+        self._subunit.stopTest(test)
+        self._stream.flush()
+
+    def stop_tests(self):
+        """Clean up the output state after a collection of tests."""
+        self._stream.flush()
+
+    def test_success(self, test, seconds):
+        self._emit_timestamp()
+        self._subunit.addSuccess(test)
+
+    def test_skipped(self, test, reason):
+        self._subunit.addSkip(test, reason)
+
+    def import_errors(self, import_errors):
+        """Report test-module import errors (if any)."""
+        if not import_errors:
+            return
+        for error in import_errors:
+            self._emit_error(
+                error.module, self.TAG_IMPORT_ERROR, error.exc_info)
+
+    def modules_with_import_problems(self, import_errors):
+        """Report names of modules with import problems (if any)."""
+        # This is simply a summary method, and subunit output doesn't benefit
+        # from summaries.
+        pass
+
+    def _exc_info_to_details(self, exc_info):
+        """Translate 'exc_info' into a details dictionary usable with subunit.
+        """
+        # In an ideal world, we'd use the pre-bundled 'TracebackContent' class
+        # from testtools. However, 'OutputFormatter' contains special logic to
+        # handle errors from doctests, so we have to use that and manually
+        # create an object equivalent to an instance of 'TracebackContent'.
+        formatter = OutputFormatter(None)
+        traceback = formatter.format_traceback(exc_info)
+
+        # We have no idea if the traceback is a unicode object or a bytestring
+        # with non-ASCII characters.  We had best be careful when handling it.
+        if isinstance(traceback, unicode):
+            unicode_tb = traceback
+        else:
+            # Assume the traceback was utf-8 encoded, but still be careful.
+            unicode_tb = traceback.decode('utf8', 'replace')
+
+        return {
+            'traceback': content.Content(
+                self.TRACEBACK_CONTENT_TYPE, lambda: [unicode_tb.encode('utf8')])}
+
+    def test_error(self, test, seconds, exc_info):
+        """Report that an error occurred while running a test.
+
+        Should be called right after start_test().
+
+        The next output operation should be stop_test().
+        """
+        self._emit_timestamp()
+        details = self._exc_info_to_details(exc_info)
+        self._subunit.addError(test, details=details)
+
+    def test_failure(self, test, seconds, exc_info):
+        """Report that a test failed.
+
+        Should be called right after start_test().
+
+        The next output operation should be stop_test().
+        """
+        self._emit_timestamp()
+        details = self._exc_info_to_details(exc_info)
+        self._subunit.addFailure(test, details=details)
+
+    def profiler_stats(self, stats):
+        """Report profiler stats."""
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            stats.dump_stats(filename)
+            stats_dump = open(filename)
+            try:
+                profile_content = content.Content(
+                    self.PROFILE_CONTENT_TYPE, stats_dump.read)
+                details = {'profiler-stats': profile_content}
+                # Name the test 'zope:profiler_stats' just like its tag.
+                self._emit_fake_test(
+                    self.TAG_PROFILER_STATS, self.TAG_PROFILER_STATS, details)
+            finally:
+                stats_dump.close()
+        finally:
+            os.unlink(filename)
+
+    def tests_with_errors(self, errors):
+        """Report tests with errors.
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def tests_with_failures(self, failures):
+        """Report tests with failures.
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def totals(self, n_tests, n_failures, n_errors, n_seconds, n_skipped=0):
+        """Summarize the results of all layers.
+
+        Simply not supported by the subunit formatter. Fancy summary output
+        doesn't make sense.
+        """
+        pass
+
+    def list_of_tests(self, tests, layer_name):
+        """Report a list of test names."""
+        self._enter_layer(layer_name)
+        for test in tests:
+            self._subunit.startTest(test)
+            self._subunit.addSuccess(test)
+        self._exit_layer(layer_name)
+
+    def _get_text_details(self, name, text):
+        """Get a details dictionary that just has some plain text."""
+        return {
+            name: content.Content(
+                self.PLAIN_TEXT, lambda: [text.encode('utf8')])}
+
+    def garbage(self, garbage):
+        """Report garbage generated by tests."""
+        # XXX: Really, 'garbage', 'profiler_stats' and the 'refcounts' twins
+        # ought to add extra details to a fake test that represents the
+        # summary information for the whole suite. However, there's no event
+        # on output formatters for "everything is really finished, honest". --
+        # jml, 2010-02-14
+        details = self._get_text_details('garbage', unicode(garbage))
+        self._emit_fake_test(
+            self.TAG_GARBAGE, self.TAG_GARBAGE, details)
+
+    def test_garbage(self, test, garbage):
+        """Report garbage generated by a test.
+
+        Encoded in the subunit stream as a test error. Clients can filter out
+        these tests based on the tag if they don't think garbage should fail
+        the test run.
+        """
+        # XXX: Perhaps 'test_garbage' and 'test_threads' ought to be within
+        # the output for the actual test, appended as details to whatever
+        # result the test gets. Not an option with the present API, as there's
+        # no event for "no more output for this test". -- jml, 2010-02-14
+        self._subunit.startTest(test)
+        self._emit_tag(self.TAG_GARBAGE)
+        self._subunit.addError(
+            test, details=self._get_text_details('garbage', unicode(garbage)))
+
+    def test_threads(self, test, new_threads):
+        """Report threads left behind by a test.
+
+        Encoded in the subunit stream as a test error. Clients can filter out
+        these tests based on the tag if they don't think left-over threads
+        should fail the test run.
+        """
+        self._subunit.startTest(test)
+        self._emit_tag(self.TAG_THREADS)
+        self._subunit.addError(
+            test, details=self._get_text_details('garbage', unicode(new_threads)))
+
+    def refcounts(self, rc, prev):
+        """Report a change in reference counts."""
+        details = self._get_text_details('sys-refcounts', str(rc))
+        details.update(
+            self._get_text_details('changes', str(rc - prev)))
+        # XXX: Emit the details dict as JSON?
+        self._emit_fake_test(
+            self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
+
+    def detailed_refcounts(self, track, rc, prev):
+        """Report a change in reference counts, with extra detail."""
+        details = self._get_text_details('sys-refcounts', str(rc))
+        details.update(
+            self._get_text_details('changes', str(rc - prev)))
+        details.update(
+            self._get_text_details('track', str(track.delta)))
+
+        self._emit_fake_test(
+            self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -22,10 +22,13 @@ import sys
 
 import pkg_resources
 
-from zope.testrunner.formatter import ColorfulOutputFormatter
-from zope.testrunner.formatter import OutputFormatter
-from zope.testrunner.formatter import terminal_has_colors
 from zope.testrunner.profiling import available_profilers
+from zope.testrunner.formatter import (
+    OutputFormatter,
+    ColorfulOutputFormatter,
+    SubunitOutputFormatter,
+    )
+from zope.testrunner.formatter import terminal_has_colors
 
 def _regex_search(s):
     return re.compile(s).search
@@ -212,6 +215,12 @@ reporting.add_argument(
     '--auto-color', action="store_const", const=None,
     help="""\
 Colorize the output, but only when stdout is a terminal.
+""")
+
+reporting.add_argument(
+    '--subunit', action="store_true", dest='subunit',
+    help="""\
+Use subunit output. Will not be colorized.
 """)
 
 reporting.add_argument(
@@ -564,7 +573,19 @@ def get_options(args=None, defaults=None):
         options.fail = True
         return options
 
-    if options.color:
+    if options.subunit:
+        try:
+            import subunit
+        except ImportError:
+            print("""\
+        Subunit is not installed. Please install Subunit
+        to generate subunit output.
+        """)
+            options.fail = True
+            return options
+        else:
+            options.output = SubunitOutputFormatter(options)
+    elif options.color:
         options.output = ColorfulOutputFormatter(options)
         options.output.slow_test_threshold = options.slow_test_threshold
     else:

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -674,7 +674,8 @@ def resume_tests(script_parts, options, features, layers, failures, errors,
     stdout_queue = None
     if options.processes == 1:
         result_factory = ImmediateSubprocessResult
-    elif options.verbose > 1:
+    elif (options.verbose > 1 and
+            not options.subunit and not options.subunit_v2):
         result_factory = KeepaliveSubprocessResult
         stdout_queue = Queue.Queue()
     else:

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -375,6 +375,7 @@ def test_suite():
 
     try:
         import subunit
+        subunit
     except ImportError:
         suites.append(
             doctest.DocFileSuite(
@@ -386,6 +387,7 @@ def test_suite():
         suites.append(
             doctest.DocFileSuite(
                 'testrunner-subunit.rst',
+                'testrunner-subunit-v2.rst',
                 setUp=setUp, tearDown=tearDown,
                 optionflags=optionflags,
                 checker=checker))

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -373,6 +373,30 @@ def test_suite():
             )
         )
 
+    try:
+        import subunit
+    except ImportError:
+        suites.append(
+            doctest.DocFileSuite(
+                'testrunner-subunit-err.rst',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
+    else:
+        suites.append(
+            doctest.DocFileSuite(
+                'testrunner-subunit.rst',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
+        if hasattr(sys, 'gettotalrefcount'):
+            suites.append(
+                doctest.DocFileSuite(
+                    'testrunner-subunit-leaks.rst',
+                    setUp=setUp, tearDown=tearDown,
+                    optionflags=optionflags,
+                    checker=checker))
+
     suites.append(doctest.DocFileSuite(
         'testrunner-unexpected-success.rst',
         setUp=setUp, tearDown=tearDown,

--- a/src/zope/testrunner/tests/test_subunit.py
+++ b/src/zope/testrunner/tests/test_subunit.py
@@ -1,0 +1,80 @@
+##############################################################################
+#
+# Copyright (c) 2010 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Unit tests for the testrunner's subunit integration.
+"""
+
+
+import sys
+import unittest
+
+from six import StringIO
+from zope.testrunner import formatter
+
+
+try:
+    unichr
+except NameError:
+    unichr = chr # Python 3
+
+
+try:
+    import subunit
+except ImportError:
+    def test_suite():
+        return unittest.TestSuite()
+else:
+
+    class TestSubunitTracebackPrinting(unittest.TestCase):
+
+        def makeByteStringFailure(self, text, encoding):
+            try:
+                # Note that this deliberately throws a string of bytes instead
+                # of a unicode object.  This simulates errors thrown by
+                # utf8-encoded doctests.
+                bytestr = text.encode(encoding)
+                self.fail(bytestr)
+            except self.failureException:
+                return sys.exc_info()
+
+        def setUp(self):
+            class FormatterOptions:
+                verbose=False
+            options = FormatterOptions()
+
+            self.output = StringIO()
+            self.subunit_formatter = formatter.SubunitOutputFormatter(
+                options, stream=self.output)
+
+        def test_print_failure_containing_utf8_bytestrings(self):
+            exc_info = self.makeByteStringFailure(unichr(6514), 'utf8')
+            self.subunit_formatter.test_failure(self, 0, exc_info)
+            assert "AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
+            # '\xe1\xa5\xb2'.decode('utf-8') == unichr(6514)
+
+        def test_print_error_containing_utf8_bytestrings(self):
+            exc_info = self.makeByteStringFailure(unichr(6514), 'utf8')
+            self.subunit_formatter.test_error(self, 0, exc_info)
+            assert "AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
+            # '\xe1\xa5\xb2'.decode('utf-8') == unichr(6514)
+
+        def test_print_failure_containing_latin1_bytestrings(self):
+            exc_info = self.makeByteStringFailure(unichr(241), 'latin1')
+            self.subunit_formatter.test_failure(self, 0, exc_info)
+            assert "AssertionError: \xef\xbf\xbd" in self.output.getvalue()
+            # '\xef\xbf\xbd'.decode('utf-8') = unichr(0xFFFD)
+
+    def test_suite():
+        return unittest.TestSuite((
+            unittest.makeSuite(TestSubunitTracebackPrinting),
+        ))

--- a/src/zope/testrunner/tests/test_subunit.py
+++ b/src/zope/testrunner/tests/test_subunit.py
@@ -11,14 +11,13 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-"""Unit tests for the testrunner's subunit integration.
-"""
+"""Unit tests for the testrunner's subunit integration."""
 
 
+import io
 import sys
 import unittest
 
-from six import StringIO
 from zope.testrunner import formatter
 
 
@@ -30,51 +29,76 @@ except NameError:
 
 try:
     import subunit
+    subunit
 except ImportError:
     def test_suite():
         return unittest.TestSuite()
 else:
 
-    class TestSubunitTracebackPrinting(unittest.TestCase):
+    class TestSubunitTracebackPrintingMixin(object):
 
         def makeByteStringFailure(self, text, encoding):
             try:
-                # Note that this deliberately throws a string of bytes instead
-                # of a unicode object.  This simulates errors thrown by
-                # utf8-encoded doctests.
-                bytestr = text.encode(encoding)
-                self.fail(bytestr)
+                if sys.version_info[0] < 3:
+                    # On Python 2, note that this deliberately throws a
+                    # string of bytes instead of a unicode object.  This
+                    # simulates errors thrown by utf8-encoded doctests.
+                    bytestr = text.encode(encoding)
+                    self.fail(bytestr)
+                else:
+                    # On Python 3, it's more accurate to just use the
+                    # Unicode text directly.
+                    self.fail(text)
             except self.failureException:
                 return sys.exc_info()
-
-        def setUp(self):
-            class FormatterOptions:
-                verbose=False
-            options = FormatterOptions()
-
-            self.output = StringIO()
-            self.subunit_formatter = formatter.SubunitOutputFormatter(
-                options, stream=self.output)
 
         def test_print_failure_containing_utf8_bytestrings(self):
             exc_info = self.makeByteStringFailure(unichr(6514), 'utf8')
             self.subunit_formatter.test_failure(self, 0, exc_info)
-            assert "AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
+            assert b"AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
             # '\xe1\xa5\xb2'.decode('utf-8') == unichr(6514)
 
         def test_print_error_containing_utf8_bytestrings(self):
             exc_info = self.makeByteStringFailure(unichr(6514), 'utf8')
             self.subunit_formatter.test_error(self, 0, exc_info)
-            assert "AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
+            assert b"AssertionError: \xe1\xa5\xb2" in self.output.getvalue()
             # '\xe1\xa5\xb2'.decode('utf-8') == unichr(6514)
 
+        @unittest.skipIf(
+            sys.version_info[0] >= 3,
+            'Tracebacks are always Unicode on Python 3')
         def test_print_failure_containing_latin1_bytestrings(self):
             exc_info = self.makeByteStringFailure(unichr(241), 'latin1')
             self.subunit_formatter.test_failure(self, 0, exc_info)
-            assert "AssertionError: \xef\xbf\xbd" in self.output.getvalue()
+            assert b"AssertionError: \xef\xbf\xbd" in self.output.getvalue()
             # '\xef\xbf\xbd'.decode('utf-8') = unichr(0xFFFD)
+
+    class TestSubunitTracebackPrinting(
+            unittest.TestCase, TestSubunitTracebackPrintingMixin):
+
+        def setUp(self):
+            class FormatterOptions:
+                verbose = False
+            options = FormatterOptions()
+
+            self.output = io.BytesIO()
+            self.subunit_formatter = formatter.SubunitOutputFormatter(
+                options, stream=self.output)
+
+    class TestSubunitV2TracebackPrinting(
+            unittest.TestCase, TestSubunitTracebackPrintingMixin):
+
+        def setUp(self):
+            class FormatterOptions:
+                verbose = False
+            options = FormatterOptions()
+
+            self.output = io.BytesIO()
+            self.subunit_formatter = formatter.SubunitV2OutputFormatter(
+                options, stream=self.output)
 
     def test_suite():
         return unittest.TestSuite((
             unittest.makeSuite(TestSubunitTracebackPrinting),
+            unittest.makeSuite(TestSubunitV2TracebackPrinting),
         ))

--- a/src/zope/testrunner/tests/test_subunit.py
+++ b/src/zope/testrunner/tests/test_subunit.py
@@ -74,7 +74,7 @@ else:
             # '\xef\xbf\xbd'.decode('utf-8') = unichr(0xFFFD)
 
     class TestSubunitTracebackPrinting(
-            unittest.TestCase, TestSubunitTracebackPrintingMixin):
+            TestSubunitTracebackPrintingMixin, unittest.TestCase):
 
         def setUp(self):
             class FormatterOptions:
@@ -86,7 +86,7 @@ else:
                 options, stream=self.output)
 
     class TestSubunitV2TracebackPrinting(
-            unittest.TestCase, TestSubunitTracebackPrintingMixin):
+            TestSubunitTracebackPrintingMixin, unittest.TestCase):
 
         def setUp(self):
             class FormatterOptions:
@@ -98,7 +98,4 @@ else:
                 options, stream=self.output)
 
     def test_suite():
-        return unittest.TestSuite((
-            unittest.makeSuite(TestSubunitTracebackPrinting),
-            unittest.makeSuite(TestSubunitV2TracebackPrinting),
-        ))
+        return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/badsyntax.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/badsyntax.py
@@ -1,0 +1,16 @@
+##############################################################################
+#
+# Copyright (c) 2018 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+# This is an intentional syntax error, to test module import errors.
+importx unittest

--- a/src/zope/testrunner/tests/testrunner-subunit-err.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-err.rst
@@ -1,0 +1,20 @@
+Using subunit output without subunit installed
+==============================================
+
+To use the --subunit reporting option, you must have subunit installed. If you
+do not, you will get an error message:
+
+    >>> import os.path, sys
+    >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> from zope import testrunner
+
+    >>> sys.argv = 'test --subunit'.split()
+    >>> _ = testrunner.run_internal(defaults)
+            Subunit is not installed. Please install Subunit
+            to generate subunit output.
+    <BLANKLINE>

--- a/src/zope/testrunner/tests/testrunner-subunit-err.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-err.rst
@@ -1,8 +1,8 @@
 Using subunit output without subunit installed
 ==============================================
 
-To use the --subunit reporting option, you must have subunit installed. If you
-do not, you will get an error message:
+To use the --subunit and --subunit-v2 reporting options, you must have
+subunit installed.  If you do not, you will get an error message:
 
     >>> import os.path, sys
     >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
@@ -14,6 +14,12 @@ do not, you will get an error message:
     >>> from zope import testrunner
 
     >>> sys.argv = 'test --subunit'.split()
+    >>> _ = testrunner.run_internal(defaults)
+            Subunit is not installed. Please install Subunit
+            to generate subunit output.
+    <BLANKLINE>
+
+    >>> sys.argv = 'test --subunit-v2'.split()
     >>> _ = testrunner.run_internal(defaults)
             Subunit is not installed. Please install Subunit
             to generate subunit output.

--- a/src/zope/testrunner/tests/testrunner-subunit-leaks.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-leaks.rst
@@ -1,0 +1,107 @@
+Debugging Memory Leaks with subunit output
+==========================================
+
+The --report-refcounts (-r) option can be used with the --repeat (-N)
+option to detect and diagnose memory leaks.  To use this option, you
+must configure Python with the --with-pydebug option. (On Unix, pass
+this option to configure and then build Python.)
+
+For more detailed documentation, see testrunner-leaks.txt.
+
+    >>> import os.path, sys
+    >>> directory_with_tests = os.path.join(this_directory, 'testrunner-ex')
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> from zope import testrunner
+
+Each layer is repeated the requested number of times.  For each
+iteration after the first, the system refcount and change in system
+refcount is shown. The system refcount is the total of all refcount in
+the system.  When a refcount on any object is changed, the system
+refcount is changed by the same amount.  Tests that don't leak show
+zero changes in system refcount.
+
+Let's look at an example test that leaks:
+
+    >>> sys.argv = 'test --subunit --tests-pattern leak -N2 -r'.split()
+    >>> _ = testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    test: leak.TestSomething.testleak
+    successful: leak.TestSomething.testleak
+    test: leak.TestSomething.testleak
+    successful: leak.TestSomething.testleak
+    test: zope:refcounts
+    tags: zope:refcounts
+    successful: zope:refcounts [ multipart
+    Content-Type: text/plain;charset=utf8
+    ...
+    ...\r
+    <BLANKLINE>
+    ...\r
+    <BLANKLINE>
+    Content-Type: text/plain;charset=utf8
+    ...
+    ...\r
+    <BLANKLINE>
+    ...\r
+    <BLANKLINE>
+    ]
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:tearDown
+
+Here we see that the system refcount is increasing.  If we specify a
+verbosity greater than one, we can get details broken out by object
+type (or class):
+
+    >>> sys.argv = 'test --subunit --tests-pattern leak -N2 -v -r'.split()
+    >>> _ = testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    test: leak.TestSomething.testleak
+    successful: leak.TestSomething.testleak
+    test: leak.TestSomething.testleak
+    successful: leak.TestSomething.testleak
+    test: zope:refcounts
+    tags: zope:refcounts
+    successful: zope:refcounts [ multipart
+    Content-Type: text/plain;charset=utf8
+    ...
+    ...\r
+    <BLANKLINE>
+    ...\r
+    <BLANKLINE>
+    Content-Type: text/plain;charset=utf8
+    ...
+    ...\r
+    <BLANKLINE>
+    ...\r
+    <BLANKLINE>
+    Content-Type: text/plain;charset=utf8
+    ...
+    ...\r
+    <BLANKLINE>
+    ...
+    <BLANKLINE>
+    ]
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:tearDown

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -9,7 +9,7 @@ protocol.
 First we need to make a temporary copy of the entire testing directory:
 
     >>> import os.path, sys, tempfile, shutil
-    >>> tmpdir = tempfile.mkdtemp()
+    >>> tmpdir = tempfile.mkdtemp(prefix='zope.testrunner-test-')
     >>> directory_with_tests = os.path.join(tmpdir, 'testrunner-ex')
     >>> source = os.path.join(this_directory, 'testrunner-ex')
     >>> n = len(source) + 1
@@ -188,7 +188,7 @@ themselves is often a critical part of the development process. Thus, it's
 good to be able to profile a test run.
 
     >>> import tempfile
-    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-')
+    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-test-')
 
     >>> sys.argv = [
     ...     'test', '--layer=122', '--profile=cProfile', '--subunit-v2',

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -64,19 +64,22 @@ For easier doctesting, we use a helper that summarizes the output.
 
     >>> def subunit_summarize(func, *args, **kwargs):
     ...     orig_stdout = sys.stdout
-    ...     if sys.version_info[0] >= 3:
-    ...         import io
-    ...         sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding='utf-8')
-    ...     else:
-    ...         import StringIO
-    ...         sys.stdout = StringIO.StringIO()
-    ...     ret = func(*args, **kwargs)
-    ...     sys.stdout.flush()
-    ...     buf = sys.stdout
-    ...     if sys.version_info[0] >= 3:
-    ...         buf = buf.detach()
-    ...     buf.seek(0)
-    ...     sys.stdout = orig_stdout
+    ...     try:
+    ...         if sys.version_info[0] >= 3:
+    ...             import io
+    ...             sys.stdout = io.TextIOWrapper(
+    ...                 io.BytesIO(), encoding='utf-8')
+    ...         else:
+    ...             import StringIO
+    ...             sys.stdout = StringIO.StringIO()
+    ...         ret = func(*args, **kwargs)
+    ...         sys.stdout.flush()
+    ...         buf = sys.stdout
+    ...         if sys.version_info[0] >= 3:
+    ...             buf = buf.detach()
+    ...         buf.seek(0)
+    ...     finally:
+    ...         sys.stdout = orig_stdout
     ...     case = ByteStreamToStreamResult(buf, non_subunit_name='stdout')
     ...     case.run(SummarizeResult(sys.stdout))
     ...     return ret

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -82,7 +82,7 @@ Basic output
 There is an 'inprogress' status event for the start of each test and a
 'success' status event for each successful test.
 
-Zope layer set up and tear down events are represented as tests tagged with
+Zope layer setup and teardown events are represented as tests tagged with
 'zope:layer'. This allows them to be distinguished from actual tests, provides
 a place for the layer timing information in the subunit stream and allows us
 to include error information if necessary.

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -308,8 +308,7 @@ Layers that can't be torn down
 ------------------------------
 
 A layer can have a tearDown method that raises NotImplementedError. If this is
-the case and there are no remaining tests to run, the subunit stream will say
-that the layer skipped its tearDown.
+the case, the subunit stream will say that the layer skipped its tearDown.
 
     >>> defaults = [
     ...     '--subunit-v2',

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -1,0 +1,654 @@
+Subunit v2 Output
+=================
+
+Subunit supports two protocols: v1 is largely a text protocol while v2 is
+binary.  v2 is generally more robust, but tools that consume the output of
+zope.testrunner may not expect to receive it, so we support emitting either
+protocol.
+
+First we need to make a temporary copy of the entire testing directory:
+
+    >>> import os.path, sys, tempfile, shutil
+    >>> tmpdir = tempfile.mkdtemp()
+    >>> directory_with_tests = os.path.join(tmpdir, 'testrunner-ex')
+    >>> source = os.path.join(this_directory, 'testrunner-ex')
+    >>> n = len(source) + 1
+    >>> for root, dirs, files in os.walk(source):
+    ...     dirs[:] = [d for d in dirs if d != ".svn"] # prune cruft
+    ...     os.mkdir(os.path.join(directory_with_tests, root[n:]))
+    ...     for f in files:
+    ...         _ = shutil.copy(os.path.join(root, f),
+    ...                         os.path.join(directory_with_tests, root[n:], f))
+
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> from zope import testrunner
+
+For easier doctesting, we use a helper that summarizes the output.
+
+    >>> from subunit import ByteStreamToStreamResult
+    >>> from testtools import StreamResult
+
+    >>> class SummarizeResult(StreamResult):
+    ...     def __init__(self, stream):
+    ...         self.stream = stream
+    ...         self._last_file = None
+    ...     def status(self, test_id=None, test_status=None, test_tags=None,
+    ...                runnable=True, file_name=None, file_bytes=None,
+    ...                eof=False, mime_type=None, route_code=None,
+    ...                timestamp=None):
+    ...         if (test_id, file_name) == self._last_file:
+    ...             self.stream.write(file_bytes.decode('utf-8', 'replace'))
+    ...             return
+    ...         elif self._last_file is not None:
+    ...             self.stream.write('\n')
+    ...             self._last_file = None
+    ...         if test_id is not None:
+    ...             self.stream.write('id=%s ' % (test_id,))
+    ...             if test_status is not None:
+    ...                 self.stream.write('status=%s ' % (test_status,))
+    ...             if test_tags is not None:
+    ...                 self.stream.write(
+    ...                     'tags=(%s) ' % ' '.join(sorted(test_tags)))
+    ...             if not runnable:
+    ...                 self.stream.write('!runnable ')
+    ...             self.stream.write('\n')
+    ...         if file_name is not None:
+    ...             self.stream.write('%s (%s)\n' % (file_name, mime_type))
+    ...             self.stream.write(file_bytes.decode('utf-8', 'replace'))
+    ...             self._last_file = (test_id, file_name)
+    ...         self.stream.flush()
+
+    >>> def subunit_summarize(func, *args, **kwargs):
+    ...     orig_stdout = sys.stdout
+    ...     if sys.version_info[0] >= 3:
+    ...         import io
+    ...         sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding='utf-8')
+    ...     else:
+    ...         import StringIO
+    ...         sys.stdout = StringIO.StringIO()
+    ...     ret = func(*args, **kwargs)
+    ...     sys.stdout.flush()
+    ...     buf = sys.stdout
+    ...     if sys.version_info[0] >= 3:
+    ...         buf = buf.detach()
+    ...     buf.seek(0)
+    ...     sys.stdout = orig_stdout
+    ...     case = ByteStreamToStreamResult(buf, non_subunit_name='stdout')
+    ...     case.run(SummarizeResult(sys.stdout))
+    ...     return ret
+
+
+Basic output
+------------
+
+There is an 'inprogress' status event for the start of each test and a
+'success' status event for each successful test.
+
+Zope layer set up and tear down events are represented as tests tagged with
+'zope:layer'. This allows them to be distinguished from actual tests, provides
+a place for the layer timing information in the subunit stream and allows us
+to include error information if necessary.
+
+Once the layer is set up, all future tests are tagged with
+'zope:layer:LAYER_NAME'.
+
+    >>> sys.argv = 'test --layer 122 --subunit-v2 -t TestNotMuch'.split()
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=samplelayers.Layer1:setUp status=inprogress !runnable
+    id=samplelayers.Layer1:setUp status=success tags=(zope:layer) !runnable
+    id=samplelayers.Layer12:setUp status=inprogress !runnable
+    id=samplelayers.Layer12:setUp status=success
+      tags=(zope:layer zope:layer:samplelayers.Layer1) !runnable
+    id=samplelayers.Layer122:setUp status=inprogress !runnable
+    id=samplelayers.Layer122:setUp status=success
+      tags=(zope:layer zope:layer:samplelayers.Layer1
+            zope:layer:samplelayers.Layer12) !runnable
+    id=sample1.sampletests.test122.TestNotMuch.test_1 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_1 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=sample1.sampletests.test122.TestNotMuch.test_2 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_2 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=sample1.sampletests.test122.TestNotMuch.test_3 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_3 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_1 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_1 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_2 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_2 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_3 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_3 status=success
+      tags=(zope:layer:samplelayers.Layer1 zope:layer:samplelayers.Layer12
+            zope:layer:samplelayers.Layer122)
+    id=samplelayers.Layer122:tearDown status=inprogress !runnable
+    id=samplelayers.Layer122:tearDown status=success
+      tags=(zope:layer zope:layer:samplelayers.Layer1
+            zope:layer:samplelayers.Layer12) !runnable
+    id=samplelayers.Layer12:tearDown status=inprogress !runnable
+    id=samplelayers.Layer12:tearDown status=success
+      tags=(zope:layer zope:layer:samplelayers.Layer1) !runnable
+    id=samplelayers.Layer1:tearDown status=inprogress !runnable
+    id=samplelayers.Layer1:tearDown status=success tags=(zope:layer) !runnable
+    False
+
+
+Listing tests
+-------------
+
+To list tests in subunit v2, we emit a stream of test results using the
+'exists' status without actually running the tests.
+
+Note that in this stream, we don't emit fake tests for the layer set up and
+tear down, because it simply doesn't happen.
+
+We also don't include the dependent layers in the stream (in this case Layer1
+and Layer12), since they are not provided to the reporter.
+
+    >>> sys.argv = [
+    ...     'test', '--layer', '122', '--list-tests', '--subunit-v2',
+    ...     '-t', 'TestNotMuch']
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=sample1.sampletests.test122.TestNotMuch.test_1 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_1 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    id=sample1.sampletests.test122.TestNotMuch.test_2 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_2 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    id=sample1.sampletests.test122.TestNotMuch.test_3 status=inprogress
+    id=sample1.sampletests.test122.TestNotMuch.test_3 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_1 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_1 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_2 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_2 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    id=sampletests.test122.TestNotMuch.test_3 status=inprogress
+    id=sampletests.test122.TestNotMuch.test_3 status=exists
+      tags=(zope:layer:samplelayers.Layer122)
+    False
+
+
+Profiling tests
+---------------
+
+Test suites often cover a lot of code, and the performance of test suites
+themselves is often a critical part of the development process. Thus, it's
+good to be able to profile a test run.
+
+    >>> import tempfile
+    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-')
+
+    >>> sys.argv = [
+    ...     'test', '--layer=122', '--profile=cProfile', '--subunit-v2',
+    ...     '--profile-directory', tempdir,
+    ...     '-t', 'TestNotMuch']
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=samplelayers.Layer1:setUp status=inprogress !runnable
+    ...
+    id=samplelayers.Layer1:tearDown status=success tags=(zope:layer) !runnable
+    id=zope:profiler_stats status=inprogress !runnable
+    id=zope:profiler_stats !runnable
+    profiler-stats (application/x-binary-profile)
+    ...\r
+    <BLANKLINE>
+    ...
+    id=zope:profiler_stats status=success tags=(zope:profiler_stats) !runnable
+    False
+
+    >>> import shutil
+    >>> shutil.rmtree(tempdir)
+
+
+Errors
+------
+
+Errors are recorded in the subunit stream as MIME-encoded chunks of text.
+
+(With subunit v2, errors and failures are unfortunately conflated: see
+https://bugs.launchpad.net/subunit/+bug/1740158.)
+
+    >>> sys.argv = [
+    ...     'test', '--subunit-v2', '--tests-pattern', '^sampletests_e$',
+    ...     ]
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=zope.testrunner.layer.UnitTests:setUp status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample2.sampletests_e.eek status=inprogress
+    id=sample2.sampletests_e.eek
+    traceback (text/x-traceback...)
+    Failed doctest test for sample2.sampletests_e.eek
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in eek
+    <BLANKLINE>
+    ----------------------------------------------------------------------
+    File testrunner-ex/sample2/sampletests_e.py", Line NNN, in sample2.sampletests_e.eek
+    Failed example:
+        f()
+    Exception raised:
+        Traceback (most recent call last):
+          File "<doctest sample2.sampletests_e.eek[0]>", Line NNN, in ?
+            f()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
+            g()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
+            x = y + 1
+           - __traceback_info__: I don't know what Y should be.
+        NameError: global name 'y' is not defined
+    <BLANKLINE>
+    id=sample2.sampletests_e.eek status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.sampletests_e.Test.test1 status=inprogress
+    id=sample2.sampletests_e.Test.test1 status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.sampletests_e.Test.test2 status=inprogress
+    id=sample2.sampletests_e.Test.test2 status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.sampletests_e.Test.test3 status=inprogress
+    id=sample2.sampletests_e.Test.test3
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in test3
+        f()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
+        g()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
+        x = y + 1
+       - __traceback_info__: I don't know what Y should be.
+    NameError: global name 'y' is not defined
+    <BLANKLINE>
+    id=sample2.sampletests_e.Test.test3 status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.sampletests_e.Test.test4 status=inprogress
+    id=sample2.sampletests_e.Test.test4 status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.sampletests_e.Test.test5 status=inprogress
+    id=sample2.sampletests_e.Test.test5 status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=e_rst status=inprogress
+    id=e_rst
+    traceback (text/x-traceback...)
+    Failed doctest test for e.rst
+     testrunner-ex/sample2/e.rst", line 0
+    <BLANKLINE>
+    ----------------------------------------------------------------------
+    File testrunner-ex/sample2/e.rst", Line NNN, in e.rst
+    Failed example:
+        f()
+    Exception raised:
+        Traceback (most recent call last):
+          File "<doctest e.rst[1]>", Line NNN, in ?
+            f()
+          File "<doctest e.rst[0]>", Line NNN, in f
+            return x
+        NameError: global name 'x' is not defined
+    <BLANKLINE>
+    id=e_rst status=fail tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=zope.testrunner.layer.UnitTests:tearDown status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:tearDown status=success
+      tags=(zope:layer) !runnable
+    True
+
+
+Layers that can't be torn down
+------------------------------
+
+A layer can have a tearDown method that raises NotImplementedError. If this is
+the case and there are no remaining tests to run, the subunit stream will say
+that the layer skipped its tearDown.
+
+    >>> defaults = [
+    ...     '--subunit-v2',
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> sys.argv = 'test -ssample2 --tests-pattern sampletests_ntd$'.split()
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=sample2.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample2.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample2.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample2.sampletests_ntd.Layer)
+    id=sample2.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample2.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    False
+
+
+Module import errors
+--------------------
+
+We report module import errors too. They get encoded as tests with errors. The
+name of the test is the module that could not be imported, the test's result
+is an error containing the traceback. These "tests" are tagged with
+zope:import_error.
+
+Let's create a module with some bad syntax:
+
+    >>> badsyntax_path = os.path.join(directory_with_tests,
+    ...                               "sample2", "sampletests_i.py")
+    >>> f = open(badsyntax_path, "w")
+    >>> print("importx unittest", file=f)  # syntax error
+    >>> f.close()
+
+And then run the tests:
+
+    >>> sys.argv = (
+    ...     'test --subunit-v2 --tests-pattern ^sampletests(f|_i)?$ --layer 1 '
+    ...     ).split()
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=sample2.sampletests_i status=inprogress
+    id=sample2.sampletests_i
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sampletests_i.py", line 1
+        importx unittest
+                       ^
+    SyntaxError: invalid syntax
+    <BLANKLINE>
+    id=sample2.sampletests_i status=fail tags=(zope:import_error)
+    id=sample2.sample21.sampletests_i status=inprogress
+    id=sample2.sample21.sampletests_i
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample21/sampletests_i.py", line 16, in <module>
+        import zope.testrunner.huh
+    ImportError: No module named huh
+    <BLANKLINE>
+    id=sample2.sample21.sampletests_i status=fail tags=(zope:import_error)
+    id=sample2.sample23.sampletests_i status=inprogress
+    id=sample2.sample23.sampletests_i
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample23/sampletests_i.py", line 17, in <module>
+        class Test(unittest.TestCase):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample23/sampletests_i.py", line 22, in Test
+        raise TypeError('eek')
+    TypeError: eek
+    <BLANKLINE>
+    id=sample2.sample23.sampletests_i status=fail tags=(zope:import_error)
+    id=samplelayers.Layer1:setUp status=inprogress
+    ...
+    True
+
+Of course, because we care deeply about test isolation, we're going to have to
+delete the module with bad syntax now, lest it contaminate other tests or even
+future test runs.
+
+    >>> os.unlink(badsyntax_path)
+
+
+Tests in subprocesses
+---------------------
+
+If the tearDown method raises NotImplementedError and there are remaining
+layers to run, the test runner will restart itself as a new process,
+resuming tests where it left off:
+
+    >>> sys.argv = [testrunner_script, '--tests-pattern', 'sampletests_ntd$']
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=sample1.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample1.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample1.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample1.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample1.sampletests_ntd.Layer)
+    id=sample1.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample1.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample1.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    id=Running in a subprocess. status=inprogress !runnable
+    id=Running in a subprocess. status=success tags=(zope:info_suboptimal)
+      !runnable
+    id=sample2.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample2.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample2.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample2.sampletests_ntd.Layer)
+    id=sample2.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample2.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    id=Running in a subprocess. status=inprogress !runnable
+    id=Running in a subprocess. status=success tags=(zope:info_suboptimal)
+      !runnable
+    id=sample3.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample3.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_error1 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_error1
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_error1
+        raise TypeError("Can we see errors")
+    TypeError: Can we see errors
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_error1 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_error2 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_error2
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_error2
+        raise TypeError("I hope so")
+    TypeError: I hope so
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_error2 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_fail1 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_fail1
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_fail1
+        self.assertEqual(1, 2)
+    AssertionError: 1 != 2
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_fail1 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_fail2 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_fail2
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_fail2
+        self.assertEqual(1, 3)
+    AssertionError: 1 != 3
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_fail2 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_something_else
+      status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_something_else status=success
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample3.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample3.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    True
+
+Note that debugging doesn't work when running tests in a subprocess:
+
+    >>> sys.argv = [testrunner_script, '--tests-pattern', 'sampletests_ntd$',
+    ...             '-D', ]
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=sample1.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample1.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample1.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample1.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample1.sampletests_ntd.Layer)
+    id=sample1.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample1.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample1.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    id=Running in a subprocess. status=inprogress !runnable
+    id=Running in a subprocess. status=success tags=(zope:info_suboptimal)
+      !runnable
+    id=sample2.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample2.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample2.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample2.sampletests_ntd.Layer)
+    id=sample2.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample2.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample2.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    id=Running in a subprocess. status=inprogress !runnable
+    id=Running in a subprocess. status=success tags=(zope:info_suboptimal)
+      !runnable
+    id=sample3.sampletests_ntd.Layer:setUp status=inprogress !runnable
+    id=sample3.sampletests_ntd.Layer:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_error1 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_error1
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 42, in test_error1
+        raise TypeError("Can we see errors")
+    TypeError: Can we see errors
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_error1 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=inprogress !runnable
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=success
+      tags=(zope:error_with_banner zope:layer:sample3.sampletests_ntd.Layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_error2 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_error2
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 45, in test_error2
+        raise TypeError("I hope so")
+    TypeError: I hope so
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_error2 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=inprogress !runnable
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=success
+      tags=(zope:error_with_banner zope:layer:sample3.sampletests_ntd.Layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_fail1 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_fail1
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 48, in test_fail1
+        self.assertEqual(1, 2)
+      File "/usr/lib/python2.6/unittest.py", line 350, in failUnlessEqual
+        (msg or '%r != %r' % (first, second))
+    AssertionError: 1 != 2
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_fail1 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=inprogress !runnable
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=success
+      tags=(zope:error_with_banner zope:layer:sample3.sampletests_ntd.Layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_fail2 status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_fail2
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 51, in test_fail2
+        self.assertEqual(1, 3)
+      File "/usr/lib/python2.6/unittest.py", line 350, in failUnlessEqual
+        (msg or '%r != %r' % (first, second))
+    AssertionError: 1 != 3
+    <BLANKLINE>
+    id=sample3.sampletests_ntd.TestSomething.test_fail2 status=fail
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=inprogress !runnable
+    id=Can't post-mortem debug when running a layer as a subprocess!
+      status=success
+      tags=(zope:error_with_banner zope:layer:sample3.sampletests_ntd.Layer)
+      !runnable
+    id=sample3.sampletests_ntd.TestSomething.test_something status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_something status=success
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.TestSomething.test_something_else
+      status=inprogress
+    id=sample3.sampletests_ntd.TestSomething.test_something_else status=success
+      tags=(zope:layer:sample3.sampletests_ntd.Layer)
+    id=sample3.sampletests_ntd.Layer:tearDown status=inprogress !runnable
+    id=sample3.sampletests_ntd.Layer:tearDown !runnable
+    reason (text/plain...)
+    tearDown not supported
+    id=sample3.sampletests_ntd.Layer:tearDown status=skip tags=(zope:layer)
+      !runnable
+    True
+
+
+Support skipped tests
+---------------------
+
+    >>> directory_with_skipped_tests = os.path.join(this_directory,
+    ...                                             'testrunner-ex-skip')
+    >>> skip_defaults = [
+    ...     '--path', directory_with_skipped_tests,
+    ...     '--tests-pattern', '^sample_skipped_tests$',
+    ...  ]
+    >>> sys.argv = ['test']
+    >>> subunit_summarize(
+    ...     testrunner.run_internal,
+    ...     skip_defaults + ["--subunit-v2", "-t", "TestSkipppedNoLayer"])
+    id=zope.testrunner.layer.UnitTests:setUp status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample_skipped_tests.TestSkipppedNoLayer.test_skipped status=inprogress
+    id=sample_skipped_tests.TestSkipppedNoLayer.test_skipped
+    reason (text/plain...)
+    I'm a skipped test!
+    id=sample_skipped_tests.TestSkipppedNoLayer.test_skipped status=skip
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=zope.testrunner.layer.UnitTests:tearDown status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:tearDown status=success
+      tags=(zope:layer) !runnable
+    False
+
+
+And remove the temporary directory:
+
+    >>> shutil.rmtree(tmpdir)

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -31,7 +31,7 @@ Basic output
 Subunit output is line-based, with a 'test:' line for the start of each test
 and a 'successful:' line for each successful test.
 
-Zope layer set up and tear down events are represented as tests tagged with
+Zope layer setup and teardown events are represented as tests tagged with
 'zope:layer'. This allows them to be distinguished from actual tests, provides
 a place for the layer timing information in the subunit stream and allows us
 to include error information if necessary.

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -299,8 +299,7 @@ Layers that can't be torn down
 ------------------------------
 
 A layer can have a tearDown method that raises NotImplementedError. If this is
-the case and there are no remaining tests to run, the subunit stream will say
-that the layer skipped its tearDown.
+the case, the subunit stream will say that the layer skipped its tearDown.
 
     >>> defaults = [
     ...     '--subunit',

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -1,0 +1,722 @@
+Subunit Output
+==============
+
+Subunit is a streaming protocol for interchanging test results. More
+information can be found at https://launchpad.net/subunit.  To enable
+support for ``subunit``, install it and its dependencies via the
+``zope.testrunner`` extra:
+
+    $ pip install zope.testrunner[subunit]
+
+or directly:
+
+    $ pip install python-subunit
+
+First we need to make a temporary copy of the entire testing directory:
+
+    >>> import os.path, sys, tempfile, shutil
+    >>> tmpdir = tempfile.mkdtemp()
+    >>> directory_with_tests = os.path.join(tmpdir, 'testrunner-ex')
+    >>> source = os.path.join(this_directory, 'testrunner-ex')
+    >>> n = len(source) + 1
+    >>> for root, dirs, files in os.walk(source):
+    ...     dirs[:] = [d for d in dirs if d != ".svn"] # prune cruft
+    ...     os.mkdir(os.path.join(directory_with_tests, root[n:]))
+    ...     for f in files:
+    ...         _ = shutil.copy(os.path.join(root, f),
+    ...                         os.path.join(directory_with_tests, root[n:], f))
+
+    >>> defaults = [
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> from zope import testrunner
+
+
+Basic output
+------------
+
+Subunit output is line-based, with a 'test:' line for the start of each test
+and a 'successful:' line for each successful test.
+
+Zope layer set up and tear down events are represented as tests tagged with
+'zope:layer'. This allows them to be distinguished from actual tests, provides
+a place for the layer timing information in the subunit stream and allows us
+to include error information if necessary.
+
+Once the layer is set up, all future tests are tagged with
+'zope:layer:LAYER_NAME'.
+
+    >>> sys.argv = 'test --layer 122 --subunit -t TestNotMuch'.split()
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer1:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer1:setUp
+    tags: zope:layer:samplelayers.Layer1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer12:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer12:setUp
+    tags: zope:layer:samplelayers.Layer12
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer122:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer122:setUp
+    tags: zope:layer:samplelayers.Layer122
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests.test122.TestNotMuch.test_1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests.test122.TestNotMuch.test_1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests.test122.TestNotMuch.test_2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests.test122.TestNotMuch.test_2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests.test122.TestNotMuch.test_3
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests.test122.TestNotMuch.test_3
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sampletests.test122.TestNotMuch.test_1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sampletests.test122.TestNotMuch.test_1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sampletests.test122.TestNotMuch.test_2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sampletests.test122.TestNotMuch.test_2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sampletests.test122.TestNotMuch.test_3
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sampletests.test122.TestNotMuch.test_3
+    tags: -zope:layer:samplelayers.Layer122
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer122:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer122:tearDown
+    tags: -zope:layer:samplelayers.Layer12
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer12:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer12:tearDown
+    tags: -zope:layer:samplelayers.Layer1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer1:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer1:tearDown
+    False
+
+
+Listing tests
+-------------
+
+A subunit stream is a stream of test results, more or less, so the most
+natural way of listing tests in subunit is to simply emit successful test
+results without actually running the tests.
+
+Note that in this stream, we don't emit fake tests for the layer set up and
+tear down, because it simply doesn't happen.
+
+We also don't include the dependent layers in the stream (in this case Layer1
+and Layer12), since they are not provided to the reporter.
+
+    >>> sys.argv = (
+    ...     'test --layer 122 --list-tests --subunit -t TestNotMuch').split()
+    >>> testrunner.run_internal(defaults)
+    tags: zope:layer:samplelayers.Layer122
+    test: sample1.sampletests.test122.TestNotMuch.test_1
+    successful: sample1.sampletests.test122.TestNotMuch.test_1
+    test: sample1.sampletests.test122.TestNotMuch.test_2
+    successful: sample1.sampletests.test122.TestNotMuch.test_2
+    test: sample1.sampletests.test122.TestNotMuch.test_3
+    successful: sample1.sampletests.test122.TestNotMuch.test_3
+    test: sampletests.test122.TestNotMuch.test_1
+    successful: sampletests.test122.TestNotMuch.test_1
+    test: sampletests.test122.TestNotMuch.test_2
+    successful: sampletests.test122.TestNotMuch.test_2
+    test: sampletests.test122.TestNotMuch.test_3
+    successful: sampletests.test122.TestNotMuch.test_3
+    tags: -zope:layer:samplelayers.Layer122
+    False
+
+
+Profiling tests
+---------------
+
+Test suites often cover a lot of code, and the performance of test suites
+themselves is often a critical part of the development process. Thus, it's
+good to be able to profile a test run.
+
+    >>> import tempfile
+    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-')
+
+    >>> sys.argv = [
+    ...     'test', '--layer=122', '--profile=cProfile', '--subunit',
+    ...     '--profile-directory', tempdir,
+    ...     '-t', 'TestNotMuch']
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: samplelayers.Layer1:setUp
+    ...
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: samplelayers.Layer1:tearDown
+    test: zope:profiler_stats
+    tags: zope:profiler_stats
+    successful: zope:profiler_stats [ multipart
+    Content-Type: application/x-binary-profile
+    profiler-stats
+    ...\r
+    <BLANKLINE>
+    ...
+    <BLANKLINE>
+    ]
+    False
+
+    >>> import shutil
+    >>> shutil.rmtree(tempdir)
+
+
+Errors
+------
+
+Errors are recorded in the subunit stream as MIME-encoded chunks of text.
+
+    >>> sys.argv = [
+    ...     'test', '--subunit' , '--tests-pattern', '^sampletests_e$',
+    ...     ]
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.eek
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: sample2.sampletests_e.eek [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Failed doctest test for sample2.sampletests_e.eek
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in eek
+    <BLANKLINE>
+    ----------------------------------------------------------------------
+    File testrunner-ex/sample2/sampletests_e.py", Line NNN, in sample2.sampletests_e.eek
+    Failed example:
+        f()
+    Exception raised:
+        Traceback (most recent call last):
+          File "<doctest sample2.sampletests_e.eek[0]>", Line NNN, in ?
+            f()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
+            g()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
+            x = y + 1
+           - __traceback_info__: I don't know what Y should be.
+        NameError: global name 'y' is not defined
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.Test.test1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_e.Test.test1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.Test.test2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_e.Test.test2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.Test.test3
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample2.sampletests_e.Test.test3 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in test3
+        f()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
+        g()
+     testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
+        x = y + 1
+       - __traceback_info__: I don't know what Y should be.
+    NameError: global name 'y' is not defined
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.Test.test4
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_e.Test.test4
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_e.Test.test5
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_e.Test.test5
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: e_rst
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: e_rst [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Failed doctest test for e.rst
+     testrunner-ex/sample2/e.rst", line 0
+    <BLANKLINE>
+    ----------------------------------------------------------------------
+    File testrunner-ex/sample2/e.rst", Line NNN, in e.rst
+    Failed example:
+        f()
+    Exception raised:
+        Traceback (most recent call last):
+          File "<doctest e.rst[1]>", Line NNN, in ?
+            f()
+          File "<doctest e.rst[0]>", Line NNN, in f
+            return x
+        NameError: global name 'x' is not defined
+    0\r
+    <BLANKLINE>
+    ]
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:tearDown
+    True
+
+
+Layers that can't be torn down
+------------------------------
+
+A layer can have a tearDown method that raises NotImplementedError. If this is
+the case and there are no remaining tests to run, the subunit stream will say
+that the layer skipped its tearDown.
+
+    >>> defaults = [
+    ...     '--subunit',
+    ...     '--path', directory_with_tests,
+    ...     '--tests-pattern', '^sampletestsf?$',
+    ...     ]
+
+    >>> sys.argv = 'test -ssample2 --tests-pattern sampletests_ntd$'.split()
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample2.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_ntd.TestSomething.test_something
+    tags: -zope:layer:sample2.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    skip: sample2.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    False
+
+
+Module import errors
+--------------------
+
+We report module import errors too. They get encoded as tests with errors. The
+name of the test is the module that could not be imported, the test's result
+is an error containing the traceback. These "tests" are tagged with
+zope:import_error.
+
+Let's create a module with some bad syntax:
+
+    >>> badsyntax_path = os.path.join(directory_with_tests,
+    ...                               "sample2", "sampletests_i.py")
+    >>> f = open(badsyntax_path, "w")
+    >>> print("importx unittest", file=f)  # syntax error
+    >>> f.close()
+
+And then run the tests:
+
+    >>> sys.argv = (
+    ...     'test --subunit --tests-pattern ^sampletests(f|_i)?$ --layer 1 '
+    ...     ).split()
+    >>> testrunner.run_internal(defaults)
+    test: sample2.sampletests_i
+    tags: zope:import_error
+    error: sample2.sampletests_i [
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sampletests_i.py", line 1
+        importx unittest
+                       ^
+    SyntaxError: invalid syntax
+    ]
+    test: sample2.sample21.sampletests_i
+    tags: zope:import_error
+    error: sample2.sample21.sampletests_i [
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample21/sampletests_i.py", line 16, in <module>
+        import zope.testrunner.huh
+    ImportError: No module named huh
+    ]
+    test: sample2.sample23.sampletests_i
+    tags: zope:import_error
+    error: sample2.sample23.sampletests_i [
+    Traceback (most recent call last):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample23/sampletests_i.py", line 17, in <module>
+        class Test(unittest.TestCase):
+      File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample23/sampletests_i.py", line 22, in Test
+        raise TypeError('eek')
+    TypeError: eek
+    ]
+    time: 2010-07-19 21:27:16.708260Z
+    test: samplelayers.Layer1:setUp
+    tags: zope:layer
+    ...
+    True
+
+Of course, because we care deeply about test isolation, we're going to have to
+delete the module with bad syntax now, lest it contaminate other tests or even
+future test runs.
+
+    >>> os.unlink(badsyntax_path)
+
+
+Tests in subprocesses
+---------------------
+
+If the tearDown method raises NotImplementedError and there are remaining
+layers to run, the test runner will restart itself as a new process,
+resuming tests where it left off:
+
+    >>> sys.argv = [testrunner_script, '--tests-pattern', 'sampletests_ntd$']
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample1.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests_ntd.TestSomething.test_something
+    tags: -zope:layer:sample1.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    skip: sample1.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    test: Running in a subprocess.
+    tags: zope:info_suboptimal
+    successful: Running in a subprocess.
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample2.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_ntd.TestSomething.test_something
+    tags: -zope:layer:sample2.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    skip: sample2.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    test: Running in a subprocess.
+    tags: zope:info_suboptimal
+    successful: Running in a subprocess.
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample3.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample3.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_error1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_error1 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    14F\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_error1
+        raise TypeError("Can we see errors")
+    TypeError: Can we see errors
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_error2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_error2 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    13F\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_error2
+        raise TypeError("I hope so")
+    TypeError: I hope so
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_fail1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: sample3.sampletests_ntd.TestSomething.test_fail1 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    1AA\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_fail1
+        self.assertEqual(1, 2)
+    AssertionError: 1 != 2
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_fail2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: sample3.sampletests_ntd.TestSomething.test_fail2 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    1AA\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample3/sampletests_ntd.py", Line NNN, in test_fail2
+        self.assertEqual(1, 3)
+    AssertionError: 1 != 3
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample3.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_something_else
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample3.sampletests_ntd.TestSomething.test_something_else
+    tags: -zope:layer:sample3.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    skip: sample3.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    True
+
+Note that debugging doesn't work when running tests in a subprocess:
+
+    >>> sys.argv = [testrunner_script, '--tests-pattern', 'sampletests_ntd$',
+    ...             '-D', ]
+    >>> testrunner.run_internal(defaults)
+    time: 2010-02-10 22:41:25.279692Z
+    test: sample1.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: 2010-02-10 22:41:25.279695Z
+    successful: sample1.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample1.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample1.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample1.sampletests_ntd.TestSomething.test_something
+    tags: -zope:layer:sample1.sampletests_ntd.Layer
+    time: 2010-02-10 22:41:25.310078Z
+    test: sample1.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: 2010-02-10 22:41:25.310171Z
+    skip: sample1.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    test: Running in a subprocess.
+    tags: zope:info_suboptimal
+    successful: Running in a subprocess.
+    time: 2010-02-10 22:41:25.753076Z
+    test: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: 2010-02-10 22:41:25.753079Z
+    successful: sample2.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample2.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.sampletests_ntd.TestSomething.test_something
+    tags: -zope:layer:sample2.sampletests_ntd.Layer
+    time: 2010-02-10 22:41:25.779256Z
+    test: sample2.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: 2010-02-10 22:41:25.779326Z
+    skip: sample2.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    test: Running in a subprocess.
+    tags: zope:info_suboptimal
+    successful: Running in a subprocess.
+    time: 2010-02-10 22:41:26.310296Z
+    test: sample3.sampletests_ntd.Layer:setUp
+    tags: zope:layer
+    time: 2010-02-10 22:41:26.310299Z
+    successful: sample3.sampletests_ntd.Layer:setUp
+    tags: zope:layer:sample3.sampletests_ntd.Layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_error1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_error1 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    16A\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 42, in test_error1
+        raise TypeError("Can we see errors")
+    TypeError: Can we see errors
+    0\r
+    <BLANKLINE>
+    ]
+    test: Can't post-mortem debug when running a layer as a subprocess!
+    tags: zope:error_with_banner
+    successful: Can't post-mortem debug when running a layer as a subprocess!
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_error2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_error2 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    15A\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 45, in test_error2
+        raise TypeError("I hope so")
+    TypeError: I hope so
+    0\r
+    <BLANKLINE>
+    ]
+    test: Can't post-mortem debug when running a layer as a subprocess!
+    tags: zope:error_with_banner
+    successful: Can't post-mortem debug when running a layer as a subprocess!
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_fail1
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_fail1 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    1C5\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 48, in test_fail1
+        self.assertEqual(1, 2)
+      File "/usr/lib/python2.6/unittest.py", line 350, in failUnlessEqual
+        (msg or '%r != %r' % (first, second))
+    AssertionError: 1 != 2
+    0\r
+    <BLANKLINE>
+    ]
+    test: Can't post-mortem debug when running a layer as a subprocess!
+    tags: zope:error_with_banner
+    successful: Can't post-mortem debug when running a layer as a subprocess!
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_fail2
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample3.sampletests_ntd.TestSomething.test_fail2 [ multipart
+    Content-Type: text/x-traceback...
+    traceback
+    1C5\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+      File "/usr/lib/python2.6/unittest.py", line 305, in debug
+        getattr(self, self._testMethodName)()
+      File "/home/jml/src/zope.testrunner/subunit-output-formatter/src/zope/testing/testrunner/testrunner-ex/sample3/sampletests_ntd.py", line 51, in test_fail2
+        self.assertEqual(1, 3)
+      File "/usr/lib/python2.6/unittest.py", line 350, in failUnlessEqual
+        (msg or '%r != %r' % (first, second))
+    AssertionError: 1 != 3
+    0\r
+    <BLANKLINE>
+    ]
+    test: Can't post-mortem debug when running a layer as a subprocess!
+    tags: zope:error_with_banner
+    successful: Can't post-mortem debug when running a layer as a subprocess!
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample3.sampletests_ntd.TestSomething.test_something
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample3.sampletests_ntd.TestSomething.test_something_else
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample3.sampletests_ntd.TestSomething.test_something_else
+    tags: -zope:layer:sample3.sampletests_ntd.Layer
+    time: 2010-02-10 22:41:26.340878Z
+    test: sample3.sampletests_ntd.Layer:tearDown
+    tags: zope:layer
+    time: 2010-02-10 22:41:26.340945Z
+    skip: sample3.sampletests_ntd.Layer:tearDown [
+    tearDown not supported
+    ]
+    True
+
+
+Support skipped tests
+---------------------
+
+    >>> directory_with_skipped_tests = os.path.join(this_directory,
+    ...                                             'testrunner-ex-skip')
+    >>> skip_defaults = [
+    ...     '--path', directory_with_skipped_tests,
+    ...     '--tests-pattern', '^sample_skipped_tests$',
+    ...  ]
+    >>> sys.argv = ['test']
+    >>> testrunner.run_internal(
+    ...     skip_defaults + ["--subunit", "-t", "TestSkipppedNoLayer"])
+    time: ...
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: ...
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    time: ...
+    test: sample_skipped_tests.TestSkipppedNoLayer.test_skipped
+    skip: sample_skipped_tests.TestSkipppedNoLayer.test_skipped [
+    I'm a skipped test!
+    ]
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: ...
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: ...
+    successful: zope.testrunner.layer.UnitTests:tearDown
+    False
+
+
+And remove the temporary directory:
+
+    >>> shutil.rmtree(tmpdir)
+

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -15,7 +15,7 @@ or directly:
 First we need to make a temporary copy of the entire testing directory:
 
     >>> import os.path, sys, tempfile, shutil
-    >>> tmpdir = tempfile.mkdtemp()
+    >>> tmpdir = tempfile.mkdtemp(prefix='zope.testrunner-test-')
     >>> directory_with_tests = os.path.join(tmpdir, 'testrunner-ex')
     >>> source = os.path.join(this_directory, 'testrunner-ex')
     >>> n = len(source) + 1
@@ -154,7 +154,7 @@ themselves is often a critical part of the development process. Thus, it's
 good to be able to profile a test run.
 
     >>> import tempfile
-    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-')
+    >>> tempdir = tempfile.mkdtemp(prefix='zope.testrunner-test-')
 
     >>> sys.argv = [
     ...     'test', '--layer=122', '--profile=cProfile', '--subunit',

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -719,4 +719,3 @@ Support skipped tests
 And remove the temporary directory:
 
     >>> shutil.rmtree(tmpdir)
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py27,pypy,py34,py35,py36,pypy3,py27-subunit,pypy-subunit,coverage,docs
+    py{27,py,34,35,36}{,-subunit},coverage,docs
 
 [testenv]
 deps =
     .[test]
-    subunit: python-subunit
+    subunit: .[subunit]
 commands =
     python setup.py -q test -q
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    py27,pypy,py34,py35,py36,pypy3,coverage,docs
+    py27,pypy,py34,py35,py36,pypy3,py27-subunit,pypy-subunit,coverage,docs
 
 [testenv]
 deps =
     .[test]
+    subunit: python-subunit
 commands =
     python setup.py -q test -q
 


### PR DESCRIPTION
This reintroduces the support for subunit that was dropped in 4.7.0, and
adds support for the subunit v2 protocol as suggested by @rbtcollins in
#23.  The runner now makes bytes/text distinctions that match those
expected by subunit, and the subunit options are now tested on all
supported Python versions.

There are still reasons why users might prefer to use subunit v1: for
instance, they might be processing the output using a version of subunit
that's too old to support the v2 protocol, or they might rely on the
distinction between failures and errors
(https://bugs.launchpad.net/subunit/+bug/1740158).  I've therefore
preserved the `--subunit` option for v1 and added a new `--subunit-v2`
option.