### PR TITLE
Enable subunit in tox -e coverage and run under Python 3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,24 +3,26 @@ envlist =
     py{27,py,34,35,36,37}{,-subunit},coverage,docs
 
 [testenv]
-deps =
-    .[test]
-    subunit: .[subunit]
+extras =
+    test
+    subunit: subunit
 commands =
     python setup.py -q test -q
 
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python2.7
+    python3
 commands =
     coverage run setup.py -q test -q
     coverage combine
     coverage report --fail-under=85
 setenv =
     COVERAGE_PROCESS_START = {toxinidir}/.coveragerc
+extras =
+    test
+    subunit
 deps =
-    .[test]
     coverage
 
 [testenv:docs]
@@ -28,5 +30,6 @@ basepython =
     python3.6
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-deps =
-    .[test,docs]
+extras =
+    test
+    docs


### PR DESCRIPTION
Fixes #78 (thanks @jamadden!).

I haven't investigated why test coverage is lower on Python 2 (55%) vs on Python 3 (80%).