### PR TITLE
Encode layer output if needed as UTF-8 before writing it to a buffer …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.9.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix ``TypeError: a bytes-like object is required, not 'str'``
+  running tests in parallel on Python 3. See `issue 80
+  <https://github.com/zopefoundation/zope.testrunner/issues/80>`_.
 
 
 4.9.1 (2018-11-21)

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -697,6 +697,7 @@ def resume_tests(script_parts, options, features, layers, failures, errors,
     current_result = next(results_iter)
     last_layer_intermediate_output = None
     output = None
+    # Get an object that (only) accepts bytes
     stdout = _get_output_buffer(sys.stdout)
     while ready_threads or running_threads:
         while len(running_threads) < options.processes and ready_threads:
@@ -723,6 +724,8 @@ def resume_tests(script_parts, options, features, layers, failures, errors,
                     ('[Parallel tests running in '
                      '%s:\n  ' % (layer_name,)).encode('utf-8'))
                 last_layer_intermediate_output = layer_name
+            if not isinstance(output, bytes):
+                output = output.encode('utf-8')
             stdout.write(output)
         # Display results in the order they would have been displayed, had the
         # work not been done in parallel.


### PR DESCRIPTION
…that explicitly (only) accepts bytes.

Update the test case to make this explicit. There are three test failures without doing the encoding.

Fixes #80