### PR TITLE
Fix test failures on Python 3.8.0a1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - 2.7
@@ -11,11 +10,15 @@ matrix:
     include:
         - python: "3.7"
           dist: xenial
-          sudo: true
           env: SUBUNIT=true
         - python: "3.7"
           dist: xenial
-          sudo: true
+          env: SUBUNIT=false
+        - python: "3.8-dev"
+          dist: xenial
+          env: SUBUNIT=true
+        - python: "3.8-dev"
+          dist: xenial
           env: SUBUNIT=false
 env:
   - SUBUNIT=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - python -m pip install -U setuptools pip
   # NB: pip install -e .[test] fails for obscure namespace package reasons
   - pip install -U .[test]
-  - ps: if($env:SUBUNIT -eq 1) { pip install -U .[subunit] }
+  - if %SUBUNIT%==1 pip install -U .[subunit]
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
 
+  SUBUNIT: 0
+
   matrix:
     - python: 27
     - python: 27-x64

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -230,10 +230,17 @@ def find_suites(options, accept=None):
                         if isinstance(suite, unittest.TestSuite):
                             check_suite(suite, module_name)
                         else:
-                            raise TypeError(
+                            # We extract the error message expression into a
+                            # local variable because we want the `raise`
+                            # statement to fit on a single line, to make the
+                            # testrunner-debugging-import-failure.rst doctest
+                            # see the same pdb output on Python 3.8 as on older
+                            # Python versions.
+                            bad_test_suite_msg = (
                                 "Invalid test_suite, %r, in %s"
                                 % (suite, module_name)
-                                )
+                            )
+                            raise TypeError(bad_test_suite_msg)
                     except KeyboardInterrupt:
                         raise
                     except:

--- a/src/zope/testrunner/tests/testrunner-colors.rst
+++ b/src/zope/testrunner/tests/testrunner-colors.rst
@@ -89,7 +89,7 @@ A failed test run highlights the failures in red:
     Exception raised:
     {red}    Traceback (most recent call last):{normal}
     {red}      File ".../doctest.py", line 1356, in __run{normal}
-    {red}        compileflags, 1)...{normal}
+    {red}        ...{normal}
     {red}      File "<doctest sample2.sampletests_e.eek[0]>", line 1, in ?{normal}
     {red}        f(){normal}
     {red}      File "testrunner-ex/sample2/sampletests_e.py", line 19, in f{normal}
@@ -127,7 +127,7 @@ A failed test run highlights the failures in red:
     Exception raised:
     {red}    Traceback (most recent call last):{normal}
     {red}      File ".../doctest.py", line 1356, in __run{normal}
-    {red}        compileflags, 1)...{normal}
+    {red}        ...{normal}
     {red}      File "<doctest e.rst[1]>", line 1, in ?{normal}
     {red}        f(){normal}
     {red}      File "<doctest e.rst[0]>", line 2, in f{normal}

--- a/src/zope/testrunner/tests/testrunner-colors.rst
+++ b/src/zope/testrunner/tests/testrunner-colors.rst
@@ -21,7 +21,7 @@ test file, let's wrap sys.stdout in a simple terminal interpreter
 
     >>> import re
     >>> class Terminal(object):
-    ...     _color_regexp = re.compile('\033[[]([0-9;]*)m')
+    ...     _color_regexp = re.compile('\033\\[([0-9;]*)m')
     ...     _colors = {'0': 'normal', '1': 'bold', '30': 'black', '31': 'red',
     ...                '32': 'green', '33': 'yellow', '34': 'blue',
     ...                '35': 'magenta', '36': 'cyan', '37': 'grey'}

--- a/src/zope/testrunner/tests/testrunner-debugging-import-failure.rst
+++ b/src/zope/testrunner/tests/testrunner-debugging-import-failure.rst
@@ -65,8 +65,8 @@ Post-mortem debugging also works when the test suite is invalid:
     ... finally: sys.stdin = real_stdin
     ... # doctest: +ELLIPSIS +REPORT_NDIFF
     TypeError: Invalid test_suite, None, in tests2
-    > ...find.py(217)find_suites()
-    -> % (suite, module_name)
+    > ...find.py(243)find_suites()
+    -> raise TypeError(bad_test_suite_msg)
     (Pdb) c
     EndRun raised
 


### PR DESCRIPTION
Prompted by https://github.com/zopefoundation/zopetoolkit/pull/32.

Tested with `tox -e py38`.
