### PR TITLE
Drop support for Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - pypy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - Fix test failures and deprecation warnings occurring when using Python 3.8a1.
   (`#89 <https://github.com/zopefoundation/zope.testrunner/pull/89>`_)
 
+- Drop support for Python 3.4.
 
 4.9.2 (2018-11-24)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,py,34,35,36,37}{,-subunit},coverage,docs
+    py{27,py,35,36,37,38}{,-subunit},coverage,docs
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.4 end of life is at 2019-03-16, see https://devguide.python.org/#status-of-python-branches

Note to self: After this PR is merge a release could be cut to help fixing zopefoundation/zopetoolkit#32.