### PR TITLE
Drop Python 3.4 from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
   matrix:
     - python: 27
     - python: 27-x64
-    - python: 34
-    - python: 34-x64
     - python: 35
     - python: 35-x64
     - python: 36
@@ -15,8 +13,6 @@ environment:
     - python: 37-x64
     - { python: 27, SUBUNIT: 1 }
     - { python: 27-x64, SUBUNIT: 1 }
-    - { python: 34, SUBUNIT: 1 }
-    - { python: 34-x64, SUBUNIT: 1 }
     - { python: 35, SUBUNIT: 1 }
     - { python: 35-x64, SUBUNIT: 1 }
     - { python: 36, SUBUNIT: 1 }


### PR DESCRIPTION
Commits 61024a6ffb and af120b1b56 dropped support for 3.4, but
appveyor.yml was missed out.