### PR TITLE
Prevent spurious --require-unique warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
 - Recover more gracefully when layer setUp or tearDown fails, producing
   useful subunit output.
 
+- Prevent a spurious warning from the ``--require-unique`` option if the
+  ``--module`` option was not used.
+
 
 5.0 (2019-03-19)
 ================

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -628,6 +628,7 @@ def get_options(args=None, defaults=None):
 
     options.ignore_dir = set(options.ignore_dir)
     options.test = options.test or ['.']
+    module_set = bool(options.module)
     options.module = options.module or ['.']
 
     options.path = options.path or []
@@ -694,7 +695,7 @@ def get_options(args=None, defaults=None):
         options.fail = True
         return options
 
-    if options.module and options.require_unique_ids:
+    if module_set and options.require_unique_ids:
         # We warn if --module and --require-unique are specified at the same
         # time, though we don't exit.
         print("""\

--- a/src/zope/testrunner/tests/testrunner-edge-cases.rst
+++ b/src/zope/testrunner/tests/testrunner-edge-cases.rst
@@ -524,3 +524,30 @@ Several tests can be excluded using the '!' notation:
     Tearing down left over layers:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
     False
+
+
+Requiring unique test IDs
+-------------------------
+
+The --require-unique option causes the test runner to require that all test
+IDs be unique.  Its behaviour is tested in zope.testrunner.tests.test_find;
+here we check its interaction with other options.
+
+The --require-unique option does not issue any warnings on its own.
+
+    >>> sys.argv = 'test --require-unique'.split()
+    >>> testrunner.run_internal(defaults)
+    ... # doctest: +ELLIPSIS
+    Running zope.testrunner.layer.UnitTests tests:
+    ...
+
+Attempting to use both --module and --require-unique issues a warning.
+
+    >>> sys.argv = 'test --module sample --require-unique'.split()
+    >>> testrunner.run_internal(defaults)
+    ... # doctest: +ELLIPSIS
+    You specified a module along with --require-unique;
+    --require-unique will not try to enforce test ID uniqueness when
+    working with a specific module.
+    Running zope.testrunner.layer.UnitTests tests:
+    ...


### PR DESCRIPTION
options.module has a default, so we can't just look at whether it's set
to determine whether to issue a warning.  Check this more carefully.

Based on work by Brad Crittenden in Launchpad's zope.testing fork.