### PR TITLE
Add test buffering, enabled by default for subunit

### DIFF
--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -364,15 +364,17 @@ class OutputFormatter(object):
     def print_std_streams(self, stdout, stderr):
         """Emit contents of buffered standard streams."""
         if stdout:
-            sys.stdout.write("\nStdout:\n")
+            sys.stdout.write("Stdout:\n")
             sys.stdout.write(stdout)
             if not stdout.endswith("\n"):
                 sys.stdout.write("\n")
+            sys.stdout.write("\n")
         if stderr:
-            sys.stderr.write("\nStderr:\n")
+            sys.stderr.write("Stderr:\n")
             sys.stderr.write(stderr)
             if not stderr.endswith("\n"):
                 sys.stderr.write("\n")
+            sys.stderr.write("\n")
 
     def format_traceback(self, exc_info):
         """Format the traceback."""

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -15,6 +15,10 @@
 """
 from __future__ import print_function
 
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 from contextlib import contextmanager
 import doctest
 import os
@@ -323,7 +327,7 @@ class OutputFormatter(object):
         sys.stdout.write(s)
         self.test_width += len(s) + 1
 
-    def test_error(self, test, seconds, exc_info):
+    def test_error(self, test, seconds, exc_info, stdout=None, stderr=None):
         """Report that an error occurred while running a test.
 
         Should be called right after start_test().
@@ -334,9 +338,10 @@ class OutputFormatter(object):
             print(" (%s)" % self.format_seconds_short(seconds))
         print()
         self.print_traceback("Error in test %s" % test, exc_info)
+        self.print_std_streams(stdout, stderr)
         self.test_width = self.last_width = 0
 
-    def test_failure(self, test, seconds, exc_info):
+    def test_failure(self, test, seconds, exc_info, stdout=None, stderr=None):
         """Report that a test failed.
 
         Should be called right after start_test().
@@ -347,6 +352,7 @@ class OutputFormatter(object):
             print(" (%s)" % self.format_seconds_short(seconds))
         print()
         self.print_traceback("Failure in test %s" % test, exc_info)
+        self.print_std_streams(stdout, stderr)
         self.test_width = self.last_width = 0
 
     def print_traceback(self, msg, exc_info):
@@ -354,6 +360,19 @@ class OutputFormatter(object):
         print()
         print(msg)
         print(self.format_traceback(exc_info))
+
+    def print_std_streams(self, stdout, stderr):
+        """Emit contents of buffered standard streams."""
+        if stdout:
+            sys.stdout.write("\nStdout:\n")
+            sys.stdout.write(stdout)
+            if not stdout.endswith("\n"):
+                sys.stdout.write("\n")
+        if stderr:
+            sys.stderr.write("\nStderr:\n")
+            sys.stderr.write(stderr)
+            if not stderr.endswith("\n"):
+                sys.stderr.write("\n")
 
     def format_traceback(self, exc_info):
         """Format the traceback."""
@@ -792,6 +811,37 @@ class _RunnableDecorator(object):
         self.decorated.status(**kwargs)
 
 
+class _SortedDict(MutableMapping, object):
+    """A dict that always returns items in sorted order.
+
+    This differs from collections.OrderedDict in that it returns items in
+    *sorted* order, not in insertion order.
+
+    We use this as a workaround for the fact that
+    testtools.ExtendedToStreamDecorator doesn't sort the details dict when
+    encoding it, which makes it difficult to write stable doctests for
+    subunit v2 output.
+    """
+
+    def __init__(self, items):
+        self._dict = dict(items)
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __setitem__(self, key, value):
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        del self._dict[key]
+
+    def __iter__(self):
+        return iter(sorted(self._dict))
+
+    def __len__(self):
+        return len(self._dict)
+
+
 class SubunitOutputFormatter(object):
     """A subunit output formatter.
 
@@ -1052,20 +1102,20 @@ class SubunitOutputFormatter(object):
 
     def refcounts(self, rc, prev):
         """Report a change in reference counts."""
-        details = {
+        details = _SortedDict({
             'sys-refcounts': text_content(str(rc)),
             'changes': text_content(str(rc - prev)),
-        }
+        })
         # XXX: Emit the details dict as JSON?
         self._emit_fake_test(self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
 
     def detailed_refcounts(self, track, rc, prev):
         """Report a change in reference counts, with extra detail."""
-        details = {
+        details = _SortedDict({
             'sys-refcounts': text_content(str(rc)),
             'changes': text_content(str(rc - prev)),
             'track': text_content(str(track.delta)),
-        }
+        })
         self._emit_fake_test(self.TAG_REFCOUNTS, self.TAG_REFCOUNTS, details)
 
     def start_set_up(self, layer_name):
@@ -1194,13 +1244,26 @@ class SubunitOutputFormatter(object):
         else:
             unicode_tb = traceback
 
-        return {
+        return _SortedDict({
             'traceback': Content(
                 self.TRACEBACK_CONTENT_TYPE,
                 lambda: [unicode_tb.encode('utf8')]),
-        }
+        })
 
-    def test_error(self, test, seconds, exc_info):
+    def _add_std_streams_to_details(self, details, stdout, stderr):
+        """Add buffered standard stream contents to a subunit details dict."""
+        if stdout:
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode('utf-8', 'replace')
+            details['test-stdout'] = Content(
+                self.PLAIN_TEXT, lambda: [stdout.encode('utf-8')])
+        if stderr:
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode('utf-8', 'replace')
+            details['test-stderr'] = Content(
+                self.PLAIN_TEXT, lambda: [stderr.encode('utf-8')])
+
+    def test_error(self, test, seconds, exc_info, stdout=None, stderr=None):
         """Report that an error occurred while running a test.
 
         Should be called right after start_test().
@@ -1209,9 +1272,10 @@ class SubunitOutputFormatter(object):
         """
         self._emit_timestamp()
         details = self._exc_info_to_details(exc_info)
+        self._add_std_streams_to_details(details, stdout, stderr)
         self._subunit.addError(test, details=details)
 
-    def test_failure(self, test, seconds, exc_info):
+    def test_failure(self, test, seconds, exc_info, stdout=None, stderr=None):
         """Report that a test failed.
 
         Should be called right after start_test().
@@ -1220,6 +1284,7 @@ class SubunitOutputFormatter(object):
         """
         self._emit_timestamp()
         details = self._exc_info_to_details(exc_info)
+        self._add_std_streams_to_details(details, stdout, stderr)
         self._subunit.addFailure(test, details=details)
 
     def stop_test(self, test):

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -285,6 +285,16 @@ This option can be used multiple times. If a thread name matches any of them,
 it will be ignored.
 """)
 
+reporting.add_argument(
+    '--buffer', action="store_true", dest="buffer",
+    help="""\
+Buffer the standard output and standard error streams during each test.
+Output during a passing test is discarded.
+Output during failing or erroring tests is echoed.
+This option is enabled by default if --subunit or --subunit-v2 is in use, to
+avoid corrupting the subunit stream.
+""")
+
 
 ######################################################################
 # Analysis
@@ -591,6 +601,7 @@ def get_options(args=None, defaults=None):
         """)
             options.fail = True
             return options
+        options.buffer = True
 
     if options.subunit and options.subunit_v2:
         print("""\

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -991,8 +991,10 @@ class TestResult(unittest.TestResult):
         # but buffer them again briefly in case testTearDown produces output
         # and confuses (e.g.) subunit.
         self._setUpStdStreams()
-        self.testTearDown()
-        self._restoreStdStreams()
+        try:
+            self.testTearDown()
+        finally:
+            self._restoreStdStreams()
         self.options.output.stop_test(test)
 
         if is_jython:

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -853,6 +853,10 @@ class TestResult(unittest.TestResult):
         for test in tests:
             count += test.countTestCases()
         self.count = count
+        self._stdout_buffer = None
+        self._stderr_buffer = None
+        self._original_stdout = sys.stdout
+        self._original_stderr = sys.stderr
 
     def testSetUp(self):
         """A layer may define a setup method to be called before each
@@ -874,7 +878,33 @@ class TestResult(unittest.TestResult):
             if hasattr(layer, 'testTearDown'):
                 layer.testTearDown()
 
+    def _setUpStdStreams(self):
+        """Set up buffered standard streams, if requested."""
+        if self.options.buffer:
+            if self._stdout_buffer is None:
+                self._stdout_buffer = StringIO()
+            if self._stderr_buffer is None:
+                self._stderr_buffer = StringIO()
+            sys.stdout = self._stdout_buffer
+            sys.stderr = self._stderr_buffer
+
+    def _restoreStdStreams(self):
+        """Restore the buffered standard streams and return any contents."""
+        if self.options.buffer:
+            stdout = sys.stdout.getvalue()
+            stderr = sys.stderr.getvalue()
+            sys.stdout = self._original_stdout
+            sys.stderr = self._original_stderr
+            self._stdout_buffer.seek(0)
+            self._stdout_buffer.truncate(0)
+            self._stderr_buffer.seek(0)
+            self._stderr_buffer.truncate(0)
+            return stdout, stderr
+        else:
+            return None, None
+
     def startTest(self, test):
+        self._setUpStdStreams()
         self.testSetUp()
         unittest.TestResult.startTest(self, test)
         testsRun = self.testsRun - 1 # subtract the one the base class added
@@ -887,16 +917,20 @@ class TestResult(unittest.TestResult):
         self._start_time = time.time()
 
     def addSuccess(self, test):
+        self._restoreStdStreams()
         t = max(time.time() - self._start_time, 0.0)
         self.options.output.test_success(test, t)
 
     def addSkip(self, test, reason):
+        self._restoreStdStreams()
         unittest.TestResult.addSkip(self, test, reason)
         self.options.output.test_skipped(test, reason)
 
     def addError(self, test, exc_info):
+        stdout, stderr = self._restoreStdStreams()
         self.options.output.test_error(test, time.time() - self._start_time,
-                                       exc_info)
+                                       exc_info,
+                                       stdout=stdout, stderr=stderr)
 
         unittest.TestResult.addError(self, test, exc_info)
 
@@ -911,8 +945,10 @@ class TestResult(unittest.TestResult):
             self.stop()
 
     def addFailure(self, test, exc_info):
+        stdout, stderr = self._restoreStdStreams()
         self.options.output.test_failure(test, time.time() - self._start_time,
-                                         exc_info)
+                                         exc_info,
+                                         stdout=stdout, stderr=stderr)
 
         unittest.TestResult.addFailure(self, test, exc_info)
 
@@ -924,15 +960,18 @@ class TestResult(unittest.TestResult):
             self.stop()
 
     def addExpectedFailure(self, test, exc_info):
+        self._restoreStdStreams()
         t = max(time.time() - self._start_time, 0.0)
         self.options.output.test_success(test, t)
 
         unittest.TestResult.addExpectedFailure(self, test, exc_info)
 
     def addUnexpectedSuccess(self, test):
+        stdout, stderr = self._restoreStdStreams()
         self.options.output.test_error(
             test, time.time() - self._start_time,
-            (UnexpectedSuccess, UnexpectedSuccess(), None))
+            (UnexpectedSuccess, UnexpectedSuccess(), None),
+            stdout=stdout, stderr=stderr)
 
         unittest.TestResult.addUnexpectedSuccess(self, test)
 
@@ -948,7 +987,12 @@ class TestResult(unittest.TestResult):
             self.stop()
 
     def stopTest(self, test):
+        # We had to restore the standard streams in order to produce output,
+        # but buffer them again briefly in case testTearDown produces output
+        # and confuses (e.g.) subunit.
+        self._setUpStdStreams()
         self.testTearDown()
+        self._restoreStdStreams()
         self.options.output.stop_test(test)
 
         if is_jython:

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -904,7 +904,6 @@ class TestResult(unittest.TestResult):
             return None, None
 
     def startTest(self, test):
-        self._setUpStdStreams()
         self.testSetUp()
         unittest.TestResult.startTest(self, test)
         testsRun = self.testsRun - 1 # subtract the one the base class added
@@ -915,6 +914,8 @@ class TestResult(unittest.TestResult):
 
         self._threads = threading.enumerate()
         self._start_time = time.time()
+
+        self._setUpStdStreams()
 
     def addSuccess(self, test):
         self._restoreStdStreams()
@@ -987,14 +988,7 @@ class TestResult(unittest.TestResult):
             self.stop()
 
     def stopTest(self, test):
-        # We had to restore the standard streams in order to produce output,
-        # but buffer them again briefly in case testTearDown produces output
-        # and confuses (e.g.) subunit.
-        self._setUpStdStreams()
-        try:
-            self.testTearDown()
-        finally:
-            self._restoreStdStreams()
+        self.testTearDown()
         self.options.output.stop_test(test)
 
         if is_jython:

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -373,13 +373,16 @@ We can ask for output on stdout and stderr to be buffered, and emitted only
 for failing and erroring tests.
 
     >>> sys.argv = (
-    ...     'test --buffer -ssample2 --tests-pattern ^stdstreamstest$'.split())
+    ...     'test -vv --buffer -ssample2'
+    ...     ' --tests-pattern ^stdstreamstest$'.split())
     >>> orig_stderr = sys.stderr
     >>> sys.stderr = sys.stdout
     >>> testrunner.run_internal(defaults) # doctest: +NORMALIZE_WHITESPACE
+    Running tests at level 1
     Running zope.testrunner.layer.UnitTests tests:
       Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
-    <BLANKLINE>
+      Running:
+     test_stderr_error (sample2.stdstreamstest.Test)
     <BLANKLINE>
     Error in test test_stderr_error (sample2.stdstreamstest.Test)
     Traceback (most recent call last):
@@ -391,6 +394,8 @@ for failing and erroring tests.
     stderr output on error
     <BLANKLINE>
     <BLANKLINE>
+     test_stderr_failure (sample2.stdstreamstest.Test)
+    <BLANKLINE>
     Failure in test test_stderr_failure (sample2.stdstreamstest.Test)
     Traceback (most recent call last):
      testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_failure
@@ -400,6 +405,9 @@ for failing and erroring tests.
     Stderr:
     stderr output on failure
     <BLANKLINE>
+    <BLANKLINE>
+     test_stderr_success (sample2.stdstreamstest.Test)
+     test_stdout_error (sample2.stdstreamstest.Test)
     <BLANKLINE>
     Error in test test_stdout_error (sample2.stdstreamstest.Test)
     Traceback (most recent call last):
@@ -411,6 +419,8 @@ for failing and erroring tests.
     stdout output on error
     <BLANKLINE>
     <BLANKLINE>
+     test_stdout_failure (sample2.stdstreamstest.Test)
+    <BLANKLINE>
     Failure in test test_stdout_failure (sample2.stdstreamstest.Test)
     Traceback (most recent call last):
      testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_failure
@@ -419,9 +429,20 @@ for failing and erroring tests.
     <BLANKLINE>
     Stdout:
     stdout output on failure
+    <BLANKLINE>
+    <BLANKLINE>
+     test_stdout_success (sample2.stdstreamstest.Test)
       Ran 6 tests with 2 failures, 2 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+    <BLANKLINE>
+    Tests with errors:
+       test_stderr_error (sample2.stdstreamstest.Test)
+       test_stdout_error (sample2.stdstreamstest.Test)
+    <BLANKLINE>
+    Tests with failures:
+       test_stderr_failure (sample2.stdstreamstest.Test)
+       test_stdout_failure (sample2.stdstreamstest.Test)
     True
     >>> sys.stderr = orig_stderr
 

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -366,6 +366,70 @@ If you also want a summary of errors at the end, ask for verbosity as well
 as progress output.
 
 
+Capturing output
+----------------
+
+We can ask for output on stdout and stderr to be buffered, and emitted only
+for failing and erroring tests.
+
+    >>> sys.argv = (
+    ...     'test --buffer -ssample2 --tests-pattern ^stdstreamstest$'.split())
+    >>> orig_stderr = sys.stderr
+    >>> sys.stderr = sys.stdout
+    >>> testrunner.run_internal(defaults) # doctest: +NORMALIZE_WHITESPACE
+    Running zope.testrunner.layer.UnitTests tests:
+      Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+    <BLANKLINE>
+    <BLANKLINE>
+    Error in test test_stderr_error (sample2.stdstreamstest.Test)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_error
+        raise Exception("boom")
+    Exception: boom
+    <BLANKLINE>
+    <BLANKLINE>
+    Stderr:
+    stderr output on error
+    <BLANKLINE>
+    <BLANKLINE>
+    Failure in test test_stderr_failure (sample2.stdstreamstest.Test)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    <BLANKLINE>
+    <BLANKLINE>
+    Stderr:
+    stderr output on failure
+    <BLANKLINE>
+    <BLANKLINE>
+    Error in test test_stdout_error (sample2.stdstreamstest.Test)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_error
+        raise Exception("boom")
+    Exception: boom
+    <BLANKLINE>
+    <BLANKLINE>
+    Stdout:
+    stdout output on error
+    <BLANKLINE>
+    <BLANKLINE>
+    Failure in test test_stdout_failure (sample2.stdstreamstest.Test)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    <BLANKLINE>
+    <BLANKLINE>
+    Stdout:
+    stdout output on failure
+      Ran 6 tests with 2 failures, 2 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+    True
+    >>> sys.stderr = orig_stderr
+
+
 Suppressing multiple doctest errors
 -----------------------------------
 

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -387,7 +387,6 @@ for failing and erroring tests.
         raise Exception("boom")
     Exception: boom
     <BLANKLINE>
-    <BLANKLINE>
     Stderr:
     stderr output on error
     <BLANKLINE>
@@ -397,7 +396,6 @@ for failing and erroring tests.
      testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_failure
         self.assertTrue(False)
     AssertionError: False is not true
-    <BLANKLINE>
     <BLANKLINE>
     Stderr:
     stderr output on failure
@@ -409,7 +407,6 @@ for failing and erroring tests.
         raise Exception("boom")
     Exception: boom
     <BLANKLINE>
-    <BLANKLINE>
     Stdout:
     stdout output on error
     <BLANKLINE>
@@ -419,7 +416,6 @@ for failing and erroring tests.
      testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_failure
         self.assertTrue(False)
     AssertionError: False is not true
-    <BLANKLINE>
     <BLANKLINE>
     Stdout:
     stdout output on failure

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/stdstreamstest.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/stdstreamstest.py
@@ -1,0 +1,47 @@
+##############################################################################
+#
+# Copyright (c) 2003 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+
+"""Sample tests that produce output on stdout and stderr."""
+
+import sys
+import unittest
+
+
+class Test(unittest.TestCase):
+
+    def test_stdout_success(self):
+        sys.stdout.write("stdout output on success\n")
+
+    def test_stdout_failure(self):
+        sys.stdout.write("stdout output on failure\n")
+        self.assertTrue(False)
+
+    def test_stdout_error(self):
+        sys.stdout.write("stdout output on error\n")
+        raise Exception("boom")
+
+    def test_stderr_success(self):
+        sys.stderr.write("stderr output on success\n")
+
+    def test_stderr_failure(self):
+        sys.stderr.write("stderr output on failure\n")
+        self.assertTrue(False)
+
+    def test_stderr_error(self):
+        sys.stderr.write("stderr output on error\n")
+        raise Exception("boom")
+
+
+def test_suite():
+    return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -291,6 +291,86 @@ https://bugs.launchpad.net/subunit/+bug/1740158.)
     True
 
 
+Capturing output
+----------------
+
+To avoid corrupting subunit streams, any output on stdout and stderr is
+buffered; for failing and erroring tests, it is recorded in the subunit
+stream as MIME-encoded chunks of text.
+
+    >>> sys.argv = 'test -ssample2 --tests-pattern ^stdstreamstest$'.split()
+    >>> subunit_summarize(testrunner.run_internal, defaults)
+    id=zope.testrunner.layer.UnitTests:setUp status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:setUp status=success tags=(zope:layer)
+      !runnable
+    id=sample2.stdstreamstest.Test.test_stderr_error status=inprogress
+    id=sample2.stdstreamstest.Test.test_stderr_error
+    test-stderr (text/plain; charset="utf8")
+    stderr output on error
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stderr_error
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_error
+        raise Exception("boom")
+    Exception: boom
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stderr_error status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.stdstreamstest.Test.test_stderr_failure status=inprogress
+    id=sample2.stdstreamstest.Test.test_stderr_failure
+    test-stderr (text/plain; charset="utf8")
+    stderr output on failure
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stderr_failure
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stderr_failure status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.stdstreamstest.Test.test_stderr_success status=inprogress
+    id=sample2.stdstreamstest.Test.test_stderr_success status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.stdstreamstest.Test.test_stdout_error status=inprogress
+    id=sample2.stdstreamstest.Test.test_stdout_error
+    test-stdout (text/plain; charset="utf8")
+    stdout output on error
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stdout_error
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_error
+        raise Exception("boom")
+    Exception: boom
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stdout_error status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.stdstreamstest.Test.test_stdout_failure status=inprogress
+    id=sample2.stdstreamstest.Test.test_stdout_failure
+    test-stdout (text/plain; charset="utf8")
+    stdout output on failure
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stdout_failure
+    traceback (text/x-traceback...)
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    <BLANKLINE>
+    id=sample2.stdstreamstest.Test.test_stdout_failure status=fail
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=sample2.stdstreamstest.Test.test_stdout_success status=inprogress
+    id=sample2.stdstreamstest.Test.test_stdout_success status=success
+      tags=(zope:layer:zope.testrunner.layer.UnitTests)
+    id=zope.testrunner.layer.UnitTests:tearDown status=inprogress !runnable
+    id=zope.testrunner.layer.UnitTests:tearDown status=success
+      tags=(zope:layer) !runnable
+    True
+
+
 Layers that can't be torn down
 ------------------------------
 

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -283,6 +283,122 @@ Errors are recorded in the subunit stream as MIME-encoded chunks of text.
     True
 
 
+Capturing output
+----------------
+
+To avoid corrupting subunit streams, any output on stdout and stderr is
+buffered; for failing and erroring tests, it is recorded in the subunit
+stream as MIME-encoded chunks of text.
+
+    >>> sys.argv = 'test -ssample2 --tests-pattern ^stdstreamstest$'.split()
+    >>> testrunner.run_internal(defaults)
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:setUp
+    tags: zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stderr_error
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample2.stdstreamstest.Test.test_stderr_error [ multipart
+    Content-Type: text/plain;charset=utf8
+    test-stderr
+    17\r
+    stderr output on error
+    0\r
+    <BLANKLINE>
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_error
+        raise Exception("boom")
+    Exception: boom
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stderr_failure
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: sample2.stdstreamstest.Test.test_stderr_failure [ multipart
+    Content-Type: text/plain;charset=utf8
+    test-stderr
+    19\r
+    stderr output on failure
+    0\r
+    <BLANKLINE>
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stderr_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stderr_success
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.stdstreamstest.Test.test_stderr_success
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stdout_error
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    error: sample2.stdstreamstest.Test.test_stdout_error [ multipart
+    Content-Type: text/plain;charset=utf8
+    test-stdout
+    17\r
+    stdout output on error
+    0\r
+    <BLANKLINE>
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_error
+        raise Exception("boom")
+    Exception: boom
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stdout_failure
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    failure: sample2.stdstreamstest.Test.test_stdout_failure [ multipart
+    Content-Type: text/plain;charset=utf8
+    test-stdout
+    19\r
+    stdout output on failure
+    0\r
+    <BLANKLINE>
+    Content-Type: text/x-traceback...
+    traceback
+    NNN\r
+    <BLANKLINE>
+    Traceback (most recent call last):
+     testrunner-ex/sample2/stdstreamstest.py", Line NNN, in test_stdout_failure
+        self.assertTrue(False)
+    AssertionError: False is not true
+    0\r
+    <BLANKLINE>
+    ]
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: sample2.stdstreamstest.Test.test_stdout_success
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: sample2.stdstreamstest.Test.test_stdout_success
+    tags: -zope:layer:zope.testrunner.layer.UnitTests
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    test: zope.testrunner.layer.UnitTests:tearDown
+    tags: zope:layer
+    time: YYYY-MM-DD HH:MM:SS.mmmmmmZ
+    successful: zope.testrunner.layer.UnitTests:tearDown
+    True
+
+
 Layers that can't be torn down
 ------------------------------
 


### PR DESCRIPTION
Python 2.7 added a --buffer option to the unittest runner with the
following description:

  "The standard output and standard error streams are buffered during
  the test run.  Output during a passing test is discarded.  Output is
  echoed normally on test fail or error and is added to the failure
  messages."

Add a matching option to zope.testrunner.

This is important for subunit output: tests that output extra things to
stdout may corrupt the subunit stream (especially with v1).  This option
is therefore always enabled for --subunit and --subunit-v2.

This is based loosely on work by Graham Binns, Benji York, and Brad
Crittenden in Launchpad's zope.testing fork; but I took a different
approach that's much closer to how modern unittest works, and I haven't
yet bothered trying to buffer output from layers (on the assumption that
there will be many fewer layers than tests, making it much easier to fix
them individually to be quiet).