### PR TITLE
Fix failure counting across layers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 - Add optional buffering of standard output and standard error during tests,
   requested via the ``--buffer`` option or enabled by default for subunit.
 
+- Fix incorrect failure counts in per-layer summary output, broken in 4.0.1.
+
 
 5.0 (2019-03-19)
 ================

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -400,14 +400,16 @@ def run_tests(options, tests, name, failures, errors, skipped, import_errors):
         t = time.time() - t
         output.stop_tests()
         failures.extend(result.failures)
+        n_failures = len(result.failures)
         if hasattr(result, 'unexpectedSuccesses'):
             # Python versions prior to 2.7 do not have the concept of
             # unexpectedSuccesses.
             failures.extend(result.unexpectedSuccesses)
+            n_failures += len(result.unexpectedSuccesses)
         skipped.extend(result.skipped)
         errors.extend(result.errors)
         output.summary(n_tests=result.testsRun,
-                       n_failures=len(failures),
+                       n_failures=n_failures,
                        n_errors=len(result.errors) + len(import_errors),
                        n_seconds=t,
                        n_skipped=len(result.skipped))

--- a/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.rst
+++ b/src/zope/testrunner/tests/testrunner-stops-when-stop-on-error.rst
@@ -35,7 +35,7 @@ When we don't pass the flag, we see two layers are tested
      testrunner-ex-37/stop_on_error.py", Line NNN, in test
         self.assertTrue(False)
     AssertionError: False is not true
-      Ran 1 tests with 2 failures, 0 errors and 0 skipped in N.NNN seconds.
+      Ran 1 tests with 1 failures, 0 errors and 0 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down layers.LayerB in N.NNN seconds.
     Total: 2 tests, 2 failures, 0 errors and 0 skipped in N.NNN seconds.


### PR DESCRIPTION
When tests in multiple layers are being run, zope.testrunner outputs a
per-layer summary after each layer, and an overall summary at the end.
The addition of support for unexpected successes in 4.0.1 caused the
per-layer summary to report incorrect failure counts: rather than
reporting the number of failures in the current layer (as for errors and
skips), it reported the cumulative number of failures so far in the
whole test run.  This was confusing, since it could result in per-layer
summaries that appeared to report failures in the layer when none
existed.

Restore the pre-4.0.1 behaviour of having the per-layer summary report
only the number of failures in that layer.