### PR TITLE
Improve standard stream handling when buffering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
  zope.testrunner Changelog
 ===========================
 
-5.2.1 (unreleased)
+5.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make standard streams provide a `buffer` attribute on Python 3 when using
+  `--buffer` or testing under subunit.
 
 
 5.2 (2020-06-29)

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -392,6 +392,7 @@ for failing and erroring tests.
     <BLANKLINE>
     Stderr:
     stderr output on error
+    stderr buffer output on error
     <BLANKLINE>
     <BLANKLINE>
      test_stderr_failure (sample2.stdstreamstest.Test)
@@ -404,6 +405,7 @@ for failing and erroring tests.
     <BLANKLINE>
     Stderr:
     stderr output on failure
+    stderr buffer output on failure
     <BLANKLINE>
     <BLANKLINE>
      test_stderr_success (sample2.stdstreamstest.Test)
@@ -417,6 +419,7 @@ for failing and erroring tests.
     <BLANKLINE>
     Stdout:
     stdout output on error
+    stdout buffer output on error
     <BLANKLINE>
     <BLANKLINE>
      test_stdout_failure (sample2.stdstreamstest.Test)
@@ -429,6 +432,7 @@ for failing and erroring tests.
     <BLANKLINE>
     Stdout:
     stdout output on failure
+    stdout buffer output on failure
     <BLANKLINE>
     <BLANKLINE>
      test_stdout_success (sample2.stdstreamstest.Test)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/stdstreamstest.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/stdstreamstest.py
@@ -20,26 +20,41 @@ import unittest
 
 class Test(unittest.TestCase):
 
+    def _getStreamBuffer(self, stream):
+        return stream.buffer if sys.version_info[0] >= 3 else stream
+
     def test_stdout_success(self):
         sys.stdout.write("stdout output on success\n")
+        self._getStreamBuffer(sys.stdout).write(
+            b"stdout buffer output on success\n")
 
     def test_stdout_failure(self):
         sys.stdout.write("stdout output on failure\n")
+        self._getStreamBuffer(sys.stdout).write(
+            b"stdout buffer output on failure\n")
         self.assertTrue(False)
 
     def test_stdout_error(self):
         sys.stdout.write("stdout output on error\n")
+        self._getStreamBuffer(sys.stdout).write(
+            b"stdout buffer output on error\n")
         raise Exception("boom")
 
     def test_stderr_success(self):
         sys.stderr.write("stderr output on success\n")
+        self._getStreamBuffer(sys.stderr).write(
+            b"stderr buffer output on success\n")
 
     def test_stderr_failure(self):
         sys.stderr.write("stderr output on failure\n")
+        self._getStreamBuffer(sys.stderr).write(
+            b"stderr buffer output on failure\n")
         self.assertTrue(False)
 
     def test_stderr_error(self):
         sys.stderr.write("stderr output on error\n")
+        self._getStreamBuffer(sys.stderr).write(
+            b"stderr buffer output on error\n")
         raise Exception("boom")
 
 

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -307,6 +307,7 @@ stream as MIME-encoded chunks of text.
     id=sample2.stdstreamstest.Test.test_stderr_error
     test-stderr (text/plain; charset="utf8")
     stderr output on error
+    stderr buffer output on error
     <BLANKLINE>
     id=sample2.stdstreamstest.Test.test_stderr_error
     traceback (text/x-traceback...)
@@ -321,6 +322,7 @@ stream as MIME-encoded chunks of text.
     id=sample2.stdstreamstest.Test.test_stderr_failure
     test-stderr (text/plain; charset="utf8")
     stderr output on failure
+    stderr buffer output on failure
     <BLANKLINE>
     id=sample2.stdstreamstest.Test.test_stderr_failure
     traceback (text/x-traceback...)
@@ -338,6 +340,7 @@ stream as MIME-encoded chunks of text.
     id=sample2.stdstreamstest.Test.test_stdout_error
     test-stdout (text/plain; charset="utf8")
     stdout output on error
+    stdout buffer output on error
     <BLANKLINE>
     id=sample2.stdstreamstest.Test.test_stdout_error
     traceback (text/x-traceback...)
@@ -352,6 +355,7 @@ stream as MIME-encoded chunks of text.
     id=sample2.stdstreamstest.Test.test_stdout_failure
     test-stdout (text/plain; charset="utf8")
     stdout output on failure
+    stdout buffer output on failure
     <BLANKLINE>
     id=sample2.stdstreamstest.Test.test_stdout_failure
     traceback (text/x-traceback...)

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -304,8 +304,9 @@ stream as MIME-encoded chunks of text.
     error: sample2.stdstreamstest.Test.test_stderr_error [ multipart
     Content-Type: text/plain;charset=utf8
     test-stderr
-    17\r
+    35\r
     stderr output on error
+    stderr buffer output on error
     0\r
     <BLANKLINE>
     Content-Type: text/x-traceback...
@@ -325,8 +326,9 @@ stream as MIME-encoded chunks of text.
     failure: sample2.stdstreamstest.Test.test_stderr_failure [ multipart
     Content-Type: text/plain;charset=utf8
     test-stderr
-    19\r
+    39\r
     stderr output on failure
+    stderr buffer output on failure
     0\r
     <BLANKLINE>
     Content-Type: text/x-traceback...
@@ -350,8 +352,9 @@ stream as MIME-encoded chunks of text.
     error: sample2.stdstreamstest.Test.test_stdout_error [ multipart
     Content-Type: text/plain;charset=utf8
     test-stdout
-    17\r
+    35\r
     stdout output on error
+    stdout buffer output on error
     0\r
     <BLANKLINE>
     Content-Type: text/x-traceback...
@@ -371,8 +374,9 @@ stream as MIME-encoded chunks of text.
     failure: sample2.stdstreamstest.Test.test_stdout_failure [ multipart
     Content-Type: text/plain;charset=utf8
     test-stdout
-    19\r
+    39\r
     stdout output on failure
+    stdout buffer output on failure
     0\r
     <BLANKLINE>
     Content-Type: text/x-traceback...


### PR DESCRIPTION
One of the last remaining issues in porting Launchpad to Python 3 is
that our CI infrastructure runs tests with subunit output (thereby
enabling test output buffering), and a few tests assume that on Python 3
they can use `sys.stdout.buffer` or `sys.stderr.buffer` to get an object
suitable for writing binary data to the standard streams.  These tests
currently fail because when zope.testrunner is doing test output
buffering it replaces the standard streams with instances of
`io.StringIO`.

Now, it's true that https://docs.python.org/3/library/sys.html notes
that "the standard streams may be replaced with file-like objects like
`io.StringIO` which do not support the `buffer` attribute"; however,
there are a couple of cases where it's difficult to work around this,
for example because the assumption is baked into existing libraries like
subunit itself.  Besides, I don't think that this note in the standard
library documentation *necessarily* means that zope.testrunner has to
do something inconvenient.

An alternative approach is to use a variant of `io.TextIOWrapper`, which
provides the `buffer` attribute for tests that need it, and can easily
be made to continue to provide the `getvalue` method for internal use.
This seems like a good compromise.