### PR TITLE
Clean up lots of lint and enable flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+per-file-ignores =
+    src/zope/testrunner/tests/test_runner.py: E701
+    src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntds.py: E702
+    src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py: E702

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,10 @@ universal = 1
 
 [flake8]
 per-file-ignores =
+    # E701: multiple statements on one line (colon)
+    # TestLayerOrdering uses this for compact declaration of class graphs.
     src/zope/testrunner/tests/test_runner.py: E701
+    # E702: multiple statements on one line (semicolon)
+    # Some tests use the "import pdb; pdb.set_trace()" idiom.
     src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntds.py: E702
     src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py: E702

--- a/src/zope/testrunner/__init__.py
+++ b/src/zope/testrunner/__init__.py
@@ -24,7 +24,8 @@ def run(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
     Will execute the tests and exit the process according to the test result.
 
     .. versionchanged:: 4.8.0
-       Add the *warnings* keyword argument. See :class:`zope.testrunner.runner.Runner`
+       Add the *warnings* keyword argument.
+       See :class:`zope.testrunner.runner.Runner`
 
     """
     failed = run_internal(defaults, args, script_parts=script_parts, cwd=cwd,
@@ -32,13 +33,15 @@ def run(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
     sys.exit(int(failed))
 
 
-def run_internal(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
+def run_internal(defaults=None, args=None, script_parts=None, cwd=None,
+                 warnings=None):
     """Execute tests.
 
     Returns whether errors or failures occured during testing.
 
     .. versionchanged:: 4.8.0
-       Add the *warnings* keyword argument. See :class:`zope.testrunner.runner.Runner`
+       Add the *warnings* keyword argument.
+       See :class:`zope.testrunner.runner.Runner`
 
     """
     if script_parts is None:
@@ -47,7 +50,8 @@ def run_internal(defaults=None, args=None, script_parts=None, cwd=None, warnings
         cwd = os.getcwd()
     # XXX Bah. Lazy import to avoid circular/early import problems
     from zope.testrunner.runner import Runner
-    runner = Runner(defaults, args, script_parts=script_parts, cwd=cwd, warnings=warnings)
+    runner = Runner(
+        defaults, args, script_parts=script_parts, cwd=cwd, warnings=warnings)
     runner.run()
     return runner.failed
 

--- a/src/zope/testrunner/_doctest.py
+++ b/src/zope/testrunner/_doctest.py
@@ -16,6 +16,8 @@
 
 import sys
 import doctest
+
+from zope.testrunner.exceptions import DocTestFailureException
 import zope.testrunner.feature
 
 
@@ -34,12 +36,14 @@ class DocTest(zope.testrunner.feature.Feature):
             reporting_flags = doctest.REPORT_NDIFF
         if options.udiff:
             if reporting_flags:
-                output.error("Can only give one of --ndiff, --udiff, or --cdiff")
+                output.error(
+                    "Can only give one of --ndiff, --udiff, or --cdiff")
                 sys.exit(1)
             reporting_flags = doctest.REPORT_UDIFF
         if options.cdiff:
             if reporting_flags:
-                output.error("Can only give one of --ndiff, --udiff, or --cdiff")
+                output.error(
+                    "Can only give one of --ndiff, --udiff, or --cdiff")
                 sys.exit(1)
             reporting_flags = doctest.REPORT_CDIFF
         if options.report_only_first_failure:
@@ -51,6 +55,6 @@ class DocTest(zope.testrunner.feature.Feature):
     def global_shutdown(self):
         doctest.set_unittest_reportflags(self.old_reporting_flags)
 
+
 # Use a special exception for the test runner.
-from zope.testrunner.exceptions import DocTestFailureException
 doctest.DocTestCase.failureException = DocTestFailureException

--- a/src/zope/testrunner/coverage.py
+++ b/src/zope/testrunner/coverage.py
@@ -27,8 +27,10 @@ from zope.testrunner.find import test_dirs
 # disabling the coverage. Simply disallow the code from doing this. A real
 # trace can be set, so that debugging still works.
 osettrace = sys.settrace
+
+
 def settrace(trace):
-    if trace is None: # pragma: no cover
+    if trace is None:  # pragma: no cover
         return
     osettrace(trace)
 
@@ -108,12 +110,13 @@ class TestIgnore(object):
     def _filenameFormat(self, filename):
         return os.path.abspath(filename)
 
+
 if sys.platform == 'win32':
-    #on win32 drive name can be passed with different case to `names`
-    #that lets e.g. the coverage profiler skip complete files
-    #_filenameFormat will make sure that all drive and filenames get lowercased
-    #albeit trace coverage has still problems with lowercase drive letters
-    #when determining the dotted module name
+    # on win32 drive name can be passed with different case to `names`
+    # that lets e.g. the coverage profiler skip complete files
+    # _filenameFormat will make sure that all drive and filenames get
+    # lowercased albeit trace coverage has still problems with lowercase
+    # drive letters when determining the dotted module name
     OldTestIgnore = TestIgnore
 
     class TestIgnore(OldTestIgnore):
@@ -132,7 +135,8 @@ class Coverage(zope.testrunner.feature.Feature):
 
     def global_setup(self):
         """Executed once when the test runner is being set up."""
-        self.directory = os.path.join(os.getcwd(), self.runner.options.coverage)
+        self.directory = os.path.join(
+            os.getcwd(), self.runner.options.coverage)
 
         # FIXME: This shouldn't rely on the find feature directly.
         self.tracer = TestTrace(test_dirs(self.runner.options, {}),

--- a/src/zope/testrunner/debug.py
+++ b/src/zope/testrunner/debug.py
@@ -68,7 +68,7 @@ def post_mortem(exc_info):
                 exec(('raise ValueError'
                       '("Expected and actual output are different")'
                       ), err.test.globs)
-            except:
+            except BaseException:
                 exc_info = sys.exc_info()
 
     print(''.join(traceback.format_exception_only(exc_info[0], exc_info[1])))

--- a/src/zope/testrunner/eggsupport.py
+++ b/src/zope/testrunner/eggsupport.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from setuptools.command.test import ScanningLoader
 from setuptools.command.test import test as BaseCommand
 
+
 def skipLayers(suite, _result=None):
     """ Walk the suite returned by setuptools' testloader.
 
@@ -25,6 +26,7 @@ def skipLayers(suite, _result=None):
         else:
             _result.addTest(test)
     return _result
+
 
 class SkipLayers(ScanningLoader):
     """
@@ -67,6 +69,7 @@ def print_usage():
     print()
     print(ftest.__doc__)
 
+
 class ftest(BaseCommand):
     """
     Run unit and functional tests after an in-place build.
@@ -74,10 +77,10 @@ class ftest(BaseCommand):
     * Note that this command runs *all* tests (unit *and* functional).
 
     * This command does not provide any of the configuration options which
-      the usual testrunner provided by 'zope.testrunner' offers:  it is intended
-      to allow easy verification that a package has been installed correctly
-      via setuptools, but is not likely to be useful for developers working
-      on the package.
+      the usual testrunner provided by 'zope.testrunner' offers:  it is
+      intended to allow easy verification that a package has been installed
+      correctly via setuptools, but is not likely to be useful for
+      developers working on the package.
 
     * Developers working on the package will likely prefer to work with
       the stock testrunner, e.g., by using buildout with a recipe which
@@ -100,10 +103,10 @@ class ftest(BaseCommand):
     help_options = [('usage', '?', 'Show usage', print_usage)]
 
     def initialize_options(self):
-        pass # suppress normal handling
+        pass  # suppress normal handling
 
     def finalize_options(self):
-        pass # suppress normal handling
+        pass  # suppress normal handling
 
     def run(self):
         from zope.testrunner import run

--- a/src/zope/testrunner/exceptions.py
+++ b/src/zope/testrunner/exceptions.py
@@ -14,5 +14,6 @@
 """Exceptions for zope.testrunner
 """
 
+
 class DocTestFailureException(AssertionError):
     """Use custom exception for doctest unit test failures"""

--- a/src/zope/testrunner/feature.py
+++ b/src/zope/testrunner/feature.py
@@ -22,7 +22,6 @@ import zope.testrunner.interfaces
 class Feature(object):
     """A base class implementing no-op methods for the IFeature interface."""
 
-
     active = False
 
     def __init__(self, runner):

--- a/src/zope/testrunner/filter.py
+++ b/src/zope/testrunner/filter.py
@@ -56,7 +56,7 @@ class Filter(zope.testrunner.feature.Feature):
                     "Cannot find layer %s" % self.runner.options.resume_layer)
                 self.runner.errors.append(
                     ("subprocess failed for %s" %
-                         self.runner.options.resume_layer,
+                        self.runner.options.resume_layer,
                      None))
         elif self.runner.options.layer:
             accept = build_filtering_func(self.runner.options.layer)
@@ -66,11 +66,12 @@ class Filter(zope.testrunner.feature.Feature):
                     layers.pop(name)
 
         if (self.runner.options.verbose and
-            not self.runner.options.resume_layer):
+                not self.runner.options.resume_layer):
             if self.runner.options.all:
                 msg = "Running tests at all levels"
             else:
-                msg = "Running tests at level %d" % self.runner.options.at_level
+                msg = (
+                    "Running tests at level %d" % self.runner.options.at_level)
             self.runner.options.output.info(msg)
 
     def report(self):
@@ -80,7 +81,8 @@ class Filter(zope.testrunner.feature.Feature):
             return
         if self.runner.options.verbose:
             self.runner.options.output.tests_with_errors(self.runner.errors)
-            self.runner.options.output.tests_with_failures(self.runner.failures)
+            self.runner.options.output.tests_with_failures(
+                self.runner.failures)
 
 
 def build_filtering_func(patterns):

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -38,10 +38,10 @@ class StartUpFailure(unittest.TestCase):
     >>> class Options(object):
     ...    post_mortem = False
     >>> options = Options()
-    
+
     Normally the StartUpFailure just acts as an empty test suite to satisfy
     the test runner and statistics:
-    
+
     >>> s = StartUpFailure(options, 'fauxmodule', None)
     >>> s
     <StartUpFailure module=fauxmodule>
@@ -89,7 +89,7 @@ class StartUpFailure(unittest.TestCase):
 
     To simulate the user pressing 'c' and hitting return in the
     debugger, we use a FakeInputContinueGenerator:
-    
+
     >>> from zope.testrunner.runner import FakeInputContinueGenerator
     >>> old_stdin = sys.stdin
     >>> sys.stdin = FakeInputContinueGenerator()
@@ -97,11 +97,12 @@ class StartUpFailure(unittest.TestCase):
     Now we can see the EndRun exception that is raised by the
     postmortem debugger to indicate that debugging is finished and the
     test run should be terminated:
-    
+
     >>> from zope.testrunner.interfaces import EndRun
     >>> try: #doctest: +ELLIPSIS
     ...   try: # try...except...finally doesn't work in Python 2.4
-    ...     print("Result:") # Needed to prevent the result from starting with '...'
+    ...     # Needed to prevent the result from starting with '...'
+    ...     print("Result:")
     ...     StartUpFailure(options, None, exc_info)
     ...   except EndRun:
     ...     print("EndRun raised")
@@ -209,11 +210,12 @@ def find_suites(options, accept=None):
                     module = import_name(module_name)
                 except KeyboardInterrupt:
                     raise
-                except:
+                except BaseException:
                     exc_info = sys.exc_info()
                     if not options.post_mortem:
                         # Skip a couple of frames
-                        exc_info = exc_info[:2] + (exc_info[2].tb_next.tb_next,)
+                        exc_info = (
+                            exc_info[:2] + (exc_info[2].tb_next.tb_next,))
                     suite = StartUpFailure(
                         options, module_name, exc_info)
                 else:
@@ -221,7 +223,8 @@ def find_suites(options, accept=None):
                         if hasattr(module, options.suite_name):
                             suite = getattr(module, options.suite_name)()
                         else:
-                            suite = unittest.defaultTestLoader.loadTestsFromModule(module)
+                            loader = unittest.defaultTestLoader
+                            suite = loader.loadTestsFromModule(module)
                             if suite.countTestCases() == 0:
                                 raise TypeError(
                                     "Module %s does not define any tests"
@@ -243,7 +246,7 @@ def find_suites(options, accept=None):
                             raise TypeError(bad_test_suite_msg)
                     except KeyboardInterrupt:
                         raise
-                    except:
+                    except BaseException:
                         exc_info = sys.exc_info()
                         if not options.post_mortem:
                             # Suppress traceback
@@ -371,6 +374,8 @@ def walk_with_symlinks(options, dir):
 
 
 compiled_suffixes = '.pyc', '.pyo'
+
+
 def remove_stale_bytecode(options):
     if options.keepbytecode:
         return
@@ -390,6 +395,7 @@ def remove_stale_bytecode(options):
                     options.output.info("Removing stale bytecode file %s"
                                         % fullname)
                     os.unlink(fullname)
+
 
 def contains_init_py(options, fnamelist):
     """Return true iff fnamelist contains a suitable spelling of __init__.py.
@@ -489,6 +495,7 @@ def check_suite(suite, module_name):
 
 _layer_name_cache = {}
 
+
 def name_from_layer(layer):
     """Determine a name for the Layer using the namespace to avoid conflicts.
 
@@ -526,4 +533,3 @@ class Find(zope.testrunner.feature.Feature):
     def report(self):
         self.runner.options.output.modules_with_import_problems(
             self.import_errors)
-

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -68,8 +68,9 @@ class OutputFormatter(object):
     progress = property(lambda self: self.options.progress)
     verbose = property(lambda self: self.options.verbose)
     in_subprocess = property(
-        lambda self: self.options.resume_layer is not None and
-                     self.options.processes > 1)
+        lambda self: (
+            self.options.resume_layer is not None and
+            self.options.processes > 1))
 
     def compute_max_width(self):
         """Try to determine the terminal width."""
@@ -173,10 +174,10 @@ class OutputFormatter(object):
     def summary(self, n_tests, n_failures, n_errors, n_seconds,
                 n_skipped=0):
         """Summarize the results of a single test layer."""
-        print ("  Ran %s tests with %s failures, %s errors and "
-               "%s skipped in %s."
-               % (n_tests, n_failures, n_errors, n_skipped,
-                   self.format_seconds(n_seconds)))
+        print("  Ran %s tests with %s failures, %s errors and "
+              "%s skipped in %s."
+              % (n_tests, n_failures, n_errors, n_skipped,
+                  self.format_seconds(n_seconds)))
 
     def totals(self, n_tests, n_failures, n_errors, n_seconds,
                n_skipped=0):
@@ -497,12 +498,14 @@ class ColorfulOutputFormatter(OutputFormatter):
                   '?': 'character-diffs',
                   '@': 'diff-chunk',
                   '*': 'diff-chunk',
-                  '!': 'actual-output',}
+                  '!': 'actual-output',
+                  }
 
     prefixes = [('dark', '0;'),
                 ('light', '1;'),
                 ('bright', '1;'),
-                ('bold', '1;'),]
+                ('bold', '1;'),
+                ]
 
     colorcodes = {'default': 0, 'normal': 0,
                   'black': 30,
@@ -514,10 +517,10 @@ class ColorfulOutputFormatter(OutputFormatter):
                   'cyan': 36,
                   'grey': 37, 'gray': 37, 'white': 37}
 
-    slow_test_threshold = 10.0 # seconds
+    slow_test_threshold = 10.0  # seconds
 
     def color_code(self, color):
-        """Convert a color description (e.g. 'lightgray') to a terminal code."""
+        """Convert a color description (e.g. 'lightred') to a terminal code."""
         prefix_code = ''
         for prefix, code in self.prefixes:
             if color.startswith(prefix):
@@ -690,7 +693,8 @@ class ColorfulOutputFormatter(OutputFormatter):
                     print(line)
             elif line.startswith('    ') or line.strip() == '':
                 if colorize_diff and len(line) > 4:
-                    color = self.diff_color.get(line[4], color_of_indented_text)
+                    color = self.diff_color.get(
+                        line[4], color_of_indented_text)
                     print(self.colorize(color, line))
                 else:
                     if line.strip() != '':

--- a/src/zope/testrunner/listing.py
+++ b/src/zope/testrunner/listing.py
@@ -29,6 +29,5 @@ class Listing(zope.testrunner.feature.Feature):
         self.runner.failed = False
 
     def report(self):
-        layers = self.runner.tests_by_layer_name
         for layer_name, layer, tests in self.runner.ordered_layers():
             self.runner.options.output.list_of_tests(tests, layer_name)

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -31,8 +31,10 @@ from zope.testrunner.formatter import (
 from zope.testrunner.formatter import terminal_has_colors
 from zope.testrunner.profiling import available_profilers
 
+
 def _regex_search(s):
     return re.compile(s).search
+
 
 parser = argparse.ArgumentParser(
     description="Discover and run unittest tests")
@@ -542,6 +544,7 @@ def merge_options(options, defaults):
         if (value is not None) and (odict[name] is None):
             odict[name] = value
 
+
 def get_options(args=None, defaults=None):
     # Because we want to inspect stdout and decide to colorize or not, we
     # replace the --auto-color option with the appropriate --color or
@@ -650,7 +653,7 @@ def get_options(args=None, defaults=None):
                          +
                          [(os.path.abspath(path), package)
                           for (path, package) in options.package_path or ()
-                         ])
+                          ])
 
     if options.package:
         pkgmap = dict(options.test_path)
@@ -679,7 +682,7 @@ def get_options(args=None, defaults=None):
         # XXX Argh.
         options.layer = ['zope.testrunner.layer.UnitTests']
 
-    options.layer = options.layer and {l: 1 for l in options.layer}
+    options.layer = options.layer and {layer: 1 for layer in options.layer}
 
     if options.usecompiled:
         options.keepbytecode = options.usecompiled
@@ -695,7 +698,6 @@ def get_options(args=None, defaults=None):
         """)
         options.fail = True
         return options
-
 
     if options.report_refcounts and not hasattr(sys, "gettotalrefcount"):
         print("""\
@@ -716,6 +718,7 @@ def get_options(args=None, defaults=None):
         """)
 
     return options
+
 
 def normalize_package(package, package_map=None):
     r"""Normalize package name passed to the --package option.

--- a/src/zope/testrunner/process.py
+++ b/src/zope/testrunner/process.py
@@ -41,10 +41,13 @@ class SubProcess(zope.testrunner.feature.Feature):
         sys.stdout.close()
         # Communicate with the parent.  The protocol is obvious:
         print(self.runner.ran,
-                len(self.runner.failures), len(self.runner.errors), file=self.original_stderr)
+              len(self.runner.failures), len(self.runner.errors),
+              file=self.original_stderr)
         for test, exc_info in self.runner.failures:
-            print(' '.join(str(test).strip().split('\n')), file=self.original_stderr)
+            print(' '.join(str(test).strip().split('\n')),
+                  file=self.original_stderr)
         for test, exc_info in self.runner.errors:
-            print(' '.join(str(test).strip().split('\n')), file=self.original_stderr)
+            print(' '.join(str(test).strip().split('\n')),
+                  file=self.original_stderr)
         # You need to flush in Python 3, and it doesn't hurt in Python 2:
         self.original_stderr.flush()

--- a/src/zope/testrunner/profiling.py
+++ b/src/zope/testrunner/profiling.py
@@ -24,7 +24,6 @@ import zope.testrunner.feature
 available_profilers = {}
 
 
-
 class CProfiler(object):
     """cProfiler"""
     def __init__(self, filepath):
@@ -45,6 +44,7 @@ class CProfiler(object):
                 stats.add(file_name)
         return stats
 
+
 available_profilers['cProfile'] = CProfiler
 
 
@@ -58,8 +58,9 @@ class Profiling(zope.testrunner.feature.Feature):
     def global_setup(self):
         self.prof_prefix = 'tests_profile.'
         self.prof_suffix = '.prof'
-        self.prof_glob = os.path.join(self.runner.options.prof_dir,
-                                      self.prof_prefix + '*' + self.prof_suffix)
+        self.prof_glob = os.path.join(
+            self.runner.options.prof_dir,
+            self.prof_prefix + '*' + self.prof_suffix)
         # if we are going to be profiling, and this isn't a subprocess,
         # clean up any stale results files
         if not self.runner.options.resume_layer:
@@ -68,7 +69,8 @@ class Profiling(zope.testrunner.feature.Feature):
         # set up the output file
         self.oshandle, self.file_path = tempfile.mkstemp(
             self.prof_suffix, self.prof_prefix, self.runner.options.prof_dir)
-        self.profiler = available_profilers[self.runner.options.profile](self.file_path)
+        self.profiler = available_profilers[self.runner.options.profile](
+            self.file_path)
 
         # Need to do this rebinding to support the stack-frame annoyance with
         # hotshot.

--- a/src/zope/testrunner/refcount.py
+++ b/src/zope/testrunner/refcount.py
@@ -46,7 +46,7 @@ class TrackRefs(object):
             n += all
 
             t = type(o)
-            if t is types.InstanceType:
+            if issubclass(t, types.InstanceType):
                 t = o.__class__
 
             if t in type2count:
@@ -55,7 +55,6 @@ class TrackRefs(object):
             else:
                 type2count[t] = 1
                 type2all[t] = all
-
 
         ct = [(
                type_or_class_title(t),
@@ -76,17 +75,17 @@ class TrackRefs(object):
         self.type2all = type2all
         self.n = n
 
-
     def output(self):
         printed = False
         s1 = s2 = 0
         for t, delta1, delta2 in self.delta:
             if delta1 or delta2:
                 if not printed:
-                    print (
+                    print(
                         '    Leak details, changes in instances and refcounts'
                         ' by type/class:')
-                    print("    %-55s %6s %6s" % ('type/class', 'insts', 'refs'))
+                    print(
+                        "    %-55s %6s %6s" % ('type/class', 'insts', 'refs'))
                     print("    %-55s %6s %6s" % ('-' * 55, '-----', '----'))
                     printed = True
                 print("    %-55s %6d %6d" % (t, delta1, delta2))
@@ -96,7 +95,6 @@ class TrackRefs(object):
         if printed:
             print("    %-55s %6s %6s" % ('-' * 55, '-----', '----'))
             print("    %-55s %6s %6s" % ('total', s1, s2))
-
 
         self.delta = None
 

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -55,10 +55,11 @@ import zope.testrunner.tb_format
 import zope.testrunner.shuffle
 
 try:
-    import Queue # Python 2
+    import Queue  # Python 2
 except ImportError:
     # Python 3
-    import queue as Queue # Python 3
+    import queue as Queue  # Python 3
+
 
 class UnexpectedSuccess(Exception):
     pass
@@ -94,11 +95,12 @@ class Runner(object):
 
     .. versionchanged:: 4.8.0
        Add the *warnings* keyword argument. If this is ``None`` (the default)
-       and the user hasn't configured Python otherwise with command-line arguments
-       or environment variables, we will enable the default warnings, including
-       ``DeprecationWarning``, when running tests. Otherwise, it can be any
-       string acceptable to :func:`warnings.simplefilter` and that filter will
-       be in effect while running tests.
+       and the user hasn't configured Python otherwise with command-line
+       arguments or environment variables, we will enable the default
+       warnings, including ``DeprecationWarning``, when running tests.
+       Otherwise, it can be any string acceptable to
+       :func:`warnings.simplefilter` and that filter will be in effect while
+       running tests.
 
     """
 
@@ -180,9 +182,9 @@ class Runner(object):
 
             # Late setup
             #
-            # Some system tools like profilers are really bad with stack frames.
-            # E.g. hotshot doesn't like it when we leave the stack frame that we
-            # called start() from.
+            # Some system tools like profilers are really bad with stack
+            # frames.  E.g. hotshot doesn't like it when we leave the stack
+            # frame that we called start() from.
             for feature in self.features:
                 feature.late_setup()
 
@@ -268,9 +270,10 @@ class Runner(object):
                 # noisy.  The -Wd and -Wa flags can be used to bypass this
                 # only when self.warnings is None.
                 if self.warnings in ['default', 'always']:
-                    warnings.filterwarnings('module',
-                                            category=DeprecationWarning,
-                                            message=r'Please use assert\w+ instead.')
+                    warnings.filterwarnings(
+                        'module',
+                        category=DeprecationWarning,
+                        message=r'Please use assert\w+ instead.')
             yield
 
     def run_tests(self):
@@ -375,7 +378,7 @@ def run_tests(options, tests, name, failures, errors, skipped, import_errors):
                         test.debug()
                     except KeyboardInterrupt:
                         raise
-                    except:
+                    except BaseException:
                         result.addError(
                             test,
                             sys.exc_info()[:2] + (sys.exc_info()[2].tb_next, ),
@@ -452,7 +455,7 @@ def run_layer(options, layer_name, layer, tests, setup_layers,
     output = options.output
     gathered = []
     gather_layers(layer, gathered)
-    needed = dict([(l, 1) for l in gathered])
+    needed = dict([(ly, 1) for ly in gathered])
     if options.resume_number != 0:
         output.info("Running %s tests:" % layer_name)
     tear_down_unneeded(options, needed, setup_layers, errors)
@@ -523,7 +526,7 @@ def spawn_layer_in_subprocess(result, script_parts, options, features,
 
         # this is because of a bug in Python (http://www.python.org/sf/900092)
         if (options.profile == 'hotshot'
-            and sys.version_info[:3] <= (2, 4, 1)):
+                and sys.version_info[:3] <= (2, 4, 1)):
             args.insert(1, '-O')
 
         debugargs = args  # save them before messing up for windows
@@ -535,7 +538,8 @@ def spawn_layer_in_subprocess(result, script_parts, options, features,
         for feature in features:
             feature.layer_setup(layer)
 
-        child = subprocess.Popen(args, shell=False, stdin=subprocess.PIPE,
+        child = subprocess.Popen(
+            args, shell=False, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd,
             close_fds=not sys.platform.startswith('win'))
 
@@ -559,10 +563,10 @@ def spawn_layer_in_subprocess(result, script_parts, options, features,
                     # return its lines as a batch). We don't want too much
                     # buffering because this foils automatic and human monitors
                     # trying to verify that the subprocess is still alive.
-                    l = child.stdout.readline()
-                    if not l:
+                    line = child.stdout.readline()
+                    if not line:
                         break
-                    result.write(l)
+                    result.write(line)
             except IOError as e:
                 if e.errno == errno.EINTR:
                     # If the subprocess dies before we finish reading its
@@ -593,7 +597,7 @@ def spawn_layer_in_subprocess(result, script_parts, options, features,
             if options.verbose >= 1:
                 errmsg += "\nChild command line: %s" % debugargs
             if (options.verbose >= 2 or
-                (options.verbose == 1 and len(errlines) < 20)):
+                    (options.verbose == 1 and len(errlines) < 20)):
                 errmsg += ("\nChild stderr was:\n" +
                            "\n".join("  " + line.decode('utf-8', 'replace')
                                      for line in errlines))
@@ -605,7 +609,6 @@ def spawn_layer_in_subprocess(result, script_parts, options, features,
                            "\n".join("  " + line.decode('utf-8', 'replace')
                                      for line in errlines[-10:]))
             output.error_with_banner(errmsg)
-
 
         while nfail > 0:
             nfail -= 1
@@ -689,7 +692,9 @@ class ImmediateSubprocessResult(AbstractSubprocessResult):
         self.stream.flush()
 
 
-_is_dots = re.compile(br'\.+(\r\n?|\n)').match # Windows sneaks in a \r\n.
+_is_dots = re.compile(br'\.+(\r\n?|\n)').match  # Windows sneaks in a \r\n.
+
+
 class KeepaliveSubprocessResult(AbstractSubprocessResult):
     "Keeps stdout for later processing; sends marks to queue to show activity."
 
@@ -782,7 +787,7 @@ def resume_tests(script_parts, options, features, layers, failures, errors,
 
         # Help keep-alive monitors (human or automated) keep up-to-date.
         stdout.flush()
-        time.sleep(0.01) # Keep the loop from being too tight.
+        time.sleep(0.01)  # Keep the loop from being too tight.
 
     # Return the total number of tests run.
     return sum(r.num_ran for r in results)
@@ -791,29 +796,30 @@ def resume_tests(script_parts, options, features, layers, failures, errors,
 def tear_down_unneeded(options, needed, setup_layers, errors, optional=False):
     # Tear down any layers not needed for these tests. The unneeded layers
     # might interfere.
-    unneeded = [l for l in setup_layers if l not in needed]
+    unneeded = [layer for layer in setup_layers if layer not in needed]
     unneeded = order_by_bases(unneeded)
     unneeded.reverse()
     output = options.output
-    for l in unneeded:
-        output.start_tear_down(name_from_layer(l))
+    for layer in unneeded:
+        output.start_tear_down(name_from_layer(layer))
         t = time.time()
         try:
             try:
-                if hasattr(l, 'tearDown'):
-                    l.tearDown()
+                if hasattr(layer, 'tearDown'):
+                    layer.tearDown()
             except NotImplementedError:
                 output.tear_down_not_supported()
                 if not optional:
-                    raise CanNotTearDown(l)
+                    raise CanNotTearDown(layer)
             except MemoryError:
                 raise
             except Exception:
-                handle_layer_failure(TearDownLayerFailure(l), output, errors)
+                handle_layer_failure(
+                    TearDownLayerFailure(layer), output, errors)
             else:
                 output.stop_tear_down(time.time() - t)
         finally:
-            del setup_layers[l]
+            del setup_layers[layer]
 
 
 cant_pm_in_subprocess_message = """
@@ -920,7 +926,7 @@ class TestResult(unittest.TestResult):
     def startTest(self, test):
         self.testSetUp()
         unittest.TestResult.startTest(self, test)
-        testsRun = self.testsRun - 1 # subtract the one the base class added
+        testsRun = self.testsRun - 1  # subtract the one the base class added
         count = test.countTestCases()
         self.testsRun = testsRun + count
 
@@ -997,7 +1003,8 @@ class TestResult(unittest.TestResult):
                                                       " as a subprocess!")
             else:
                 # XXX: what exc_info? there's no exc_info!
-                zope.testrunner.debug.post_mortem(exc_info)
+                # flake8 is correct, but keep it quiet for now ...
+                zope.testrunner.debug.post_mortem(exc_info)  # noqa: F821
         elif self.options.stop_on_error:
             self.stop()
 
@@ -1073,7 +1080,7 @@ def layer_sort_key(layer):
         key.append(layer)
 
     _gather(layer)
-    return tuple(name_from_layer(l) for l in key if l != UnitTests)
+    return tuple(name_from_layer(ly) for ly in key if ly != UnitTests)
 
 
 def order_by_bases(layers):
@@ -1109,8 +1116,8 @@ class FakeInputContinueGenerator:
     def readline(self):
         print('c\n')
         print('*'*70)
-        print ("Can't use pdb.set_trace when running a layer"
-               " as a subprocess!")
+        print("Can't use pdb.set_trace when running a layer"
+              " as a subprocess!")
         print('*'*70)
         print()
         return 'c\n'

--- a/src/zope/testrunner/shuffle.py
+++ b/src/zope/testrunner/shuffle.py
@@ -31,7 +31,7 @@ class Shuffle(zope.testrunner.feature.Feature):
             # We can't rely on the random modules seed initialization because
             # we can't introspect the seed later for reporting.  This is a
             # simple emulation of what random.Random.seed does anyway.
-            self.seed = int(time.time() * 256) # use fractional seconds
+            self.seed = int(time.time() * 256)  # use fractional seconds
 
     def global_setup(self):
         rng = random.Random(self.seed)

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -25,20 +25,20 @@ import unittest
 from zope.testing import renormalizing
 
 
-#separated checkers for the different platform,
-#because it s...s to maintain just one
+# separated checkers for the different platform,
+# because it s...s to maintain just one
 if sys.platform == 'win32':
     checker = renormalizing.RENormalizing([
         # 2.5 changed the way pdb reports exceptions
         (re.compile(r"<class 'exceptions.(\w+)Error'>:"),
          r'exceptions.\1Error:'),
 
-        #rewrite pdb prompt to ... the current location
-        #windows, py2.4 pdb seems not to put the '>' on doctest locations
-        #therefore we cut it here
+        # rewrite pdb prompt to ... the current location
+        # windows, py2.4 pdb seems not to put the '>' on doctest locations
+        # therefore we cut it here
         (re.compile('^> doctest[^\n]+->None$', re.M), '...->None'),
 
-        #rewrite pdb prompt to ... the current location
+        # rewrite pdb prompt to ... the current location
         (re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
 
         (re.compile(r"<module>"), (r'?')),
@@ -52,18 +52,21 @@ if sys.platform == 'win32':
         (re.compile(r'traceback\n[A-F\d]+', re.MULTILINE),
          r'traceback\nNNN'),
 
-        (re.compile("'[A-Za-z]:\\\\"), "'"), # hopefully, we'll make Windows happy
-                                             # replaces drives with nothing
+        # hopefully, we'll make Windows happy
+        # replaces drives with nothing
+        (re.compile("'[A-Za-z]:\\\\"), "'"),
 
-        (re.compile(r'\\\\'), '/'), # more Windows happiness
-                                    # double backslashes in coverage???
+        # more Windows happiness
+        # double backslashes in coverage???
+        (re.compile(r'\\\\'), '/'),
 
-        (re.compile(r'\\'), '/'), # even more Windows happiness
-                                  # replaces backslashes in paths
+        # even more Windows happiness
+        # replaces backslashes in paths
+        (re.compile(r'\\'), '/'),
 
-        (re.compile(r'/r$', re.MULTILINE), '\\r'), # undo some of that
+        (re.compile(r'/r$', re.MULTILINE), '\\r'),  # undo some of that
 
-        #this is a magic to put linefeeds into the doctest
+        # this is a magic to put linefeeds into the doctest
         (re.compile('##r##\n'), '\r'),
 
         (re.compile(r'(\d+ minutes )?\d+[.]\d\d\d seconds'), 'N.NNN seconds'),
@@ -78,18 +81,21 @@ if sys.platform == 'win32':
         (re.compile(r'[.]py\(\d+\)'), r'.py(NNN)'),
         (re.compile(r'[.]py:\d+'), r'.py:NNN'),
         (re.compile(r' line \d+,', re.IGNORECASE), r' Line NNN,'),
-        (re.compile(r' line {([a-z]+)}\d+{', re.IGNORECASE), r' Line {\1}NNN{'),
+        (re.compile(r' line {([a-z]+)}\d+{', re.IGNORECASE),
+         r' Line {\1}NNN{'),
 
         # omit traceback entries for unittest.py or doctest.py (and
         # their package variants) from output:
-        (re.compile(r'^ +File "[^\n]*(doctest|unittest|case)(/__init__)?.py", [^\n]+\n[^\n]+\n',
+        (re.compile(r'^ +File "[^\n]*(doctest|unittest|case)(/__init__)?.py", '
+                    r'[^\n]+\n[^\n]+\n',
                     re.MULTILINE),
          r''),
-        (re.compile(r'^{\w+} +File "{\w+}[^\n]*(doctest|unittest|case)(/__init__)?.py{\w+}", [^\n]+\n[^\n]+\n',
+        (re.compile(r'^{\w+} +File "{\w+}[^\n]*(doctest|unittest|case)'
+                    r'(/__init__)?.py{\w+}", [^\n]+\n[^\n]+\n',
                     re.MULTILINE),
          r''),
-        #(re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
-        (re.compile('import pdb; pdb'), 'Pdb()'), # Py 2.3
+        # (re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
+        (re.compile('import pdb; pdb'), 'Pdb()'),  # Py 2.3
 
         # Python 3 exceptions are from the builtins module
         (re.compile(r'builtins\.(SyntaxError|TypeError)'),
@@ -103,28 +109,29 @@ if sys.platform == 'win32':
          r'ImportError: No module named \1'),
 
         # PyPy has different exception messages too
-        (re.compile("ImportError: No module named (?:[a-zA-Z_0-9.]*[.])?([a-zA-Z_0-9]*)"),
+        (re.compile("ImportError: No module named "
+                    "(?:[a-zA-Z_0-9.]*[.])?([a-zA-Z_0-9]*)"),
          r'ImportError: No module named \1'),
         (re.compile("NameError: global name '([^']*)' is not defined"),
          r"NameError: name '\1' is not defined"),
 
         ])
 else:
-    #*nix
+    # *nix
     checker = renormalizing.RENormalizing([
         # 2.5 changed the way pdb reports exceptions
         (re.compile(r"<class 'exceptions.(\w+)Error'>:"),
          r'exceptions.\1Error:'),
 
-        #rewrite pdb prompt to ... the current location
+        # rewrite pdb prompt to ... the current location
         (re.compile('^> [^\n]+->None$', re.M), '> ...->None'),
 
         (re.compile(r"<module>"), (r'?')),
         (re.compile(r"<type 'exceptions.(\w+)Error'>:"),
          r'exceptions.\1Error:'),
 
-        #this is a magic to put linefeeds into the doctest
-        #on win it takes one step, linux is crazy about the same...
+        # this is a magic to put linefeeds into the doctest
+        # on win it takes one step, linux is crazy about the same...
         (re.compile('##r##'), r'\r'),
         (re.compile(r'\r'), '\\\\r\n'),
 
@@ -140,7 +147,8 @@ else:
         (re.compile(r'[.]py\(\d+\)'), r'.py(NNN)'),
         (re.compile(r'[.]py:\d+'), r'.py:NNN'),
         (re.compile(r' line \d+,', re.IGNORECASE), r' Line NNN,'),
-        (re.compile(r' line {([a-z]+)}\d+{', re.IGNORECASE), r' Line {\1}NNN{'),
+        (re.compile(r' line {([a-z]+)}\d+{', re.IGNORECASE),
+         r' Line {\1}NNN{'),
 
         # testtools content formatter is used to mime-encode
         # tracebacks when the SubunitOutputFormatter is used, and the
@@ -151,13 +159,15 @@ else:
 
         # omit traceback entries for unittest.py or doctest.py (and
         # their package variants) from output:
-        (re.compile(r'^ +File "[^\n]*(doctest|unittest|case)(/__init__)?.py", [^\n]+\n[^\n]+\n',
+        (re.compile(r'^ +File "[^\n]*(doctest|unittest|case)(/__init__)?.py", '
+                    r'[^\n]+\n[^\n]+\n',
                     re.MULTILINE),
          r''),
-        (re.compile(r'^{\w+} +File "{\w+}[^\n]*(doctest|unittest|case)(/__init__)?.py{\w+}", [^\n]+\n[^\n]+\n',
+        (re.compile(r'^{\w+} +File "{\w+}[^\n]*(doctest|unittest|case)'
+                    r'(/__init__)?.py{\w+}", [^\n]+\n[^\n]+\n',
                     re.MULTILINE),
          r''),
-        (re.compile('import pdb; pdb'), 'Pdb()'), # Py 2.3
+        (re.compile('import pdb; pdb'), 'Pdb()'),  # Py 2.3
 
         # Python 3 exceptions are from the builtins module
         (re.compile(r'builtins\.(SyntaxError|TypeError)'),
@@ -171,7 +181,8 @@ else:
          r'ImportError: No module named \1'),
 
         # PyPy has different exception messages too
-        (re.compile("ImportError: No module named (?:[a-zA-Z_0-9.]*[.])?([a-zA-Z_0-9]*)"),
+        (re.compile("ImportError: No module named "
+                    "(?:[a-zA-Z_0-9.]*[.])?([a-zA-Z_0-9]*)"),
          r'ImportError: No module named \1'),
         (re.compile("NameError: global name '([^']*)' is not defined"),
          r"NameError: name '\1' is not defined"),
@@ -351,7 +362,8 @@ def test_suite():
                 setUp=setUp, tearDown=tearDown,
                 optionflags=optionflags,
                 checker=renormalizing.RENormalizing([
-                    (re.compile(r'(\d+ minutes )?\d+[.]\d\d\d seconds'), 'N.NNN seconds'),
+                    (re.compile(r'(\d+ minutes )?\d+[.]\d\d\d seconds'),
+                     'N.NNN seconds'),
                     (re.compile(r'sys refcount=\d+ +change=\d+'),
                      'sys refcount=NNNNNN change=NN'),
                     (re.compile(r'sum detail refcount=\d+ +'),

--- a/src/zope/testrunner/tests/test_runner.py
+++ b/src/zope/testrunner/tests/test_runner.py
@@ -27,7 +27,8 @@ class TestLayerOrdering(unittest.TestCase):
                          for qn in runner.layer_sort_key(layer))
 
     def order(self, *layers):
-        return ', '.join(l.__name__ for l in runner.order_by_bases(layers))
+        return ', '.join(layer.__name__
+                         for layer in runner.order_by_bases(layers))
 
     def test_order_by_bases(self):
         #    A      B
@@ -181,6 +182,7 @@ class TestLayerOrdering(unittest.TestCase):
         f = runner.FakeInputContinueGenerator()
         f.close()
 
+
 @unittest.skipIf(sys.warnoptions, "Only done if no user override")
 class TestWarnings(unittest.TestCase):
 
@@ -203,7 +205,6 @@ class TestWarnings(unittest.TestCase):
         # For some reason, catch_warnings doesn't fully reset things,
         # and we wind up with some duplicate entries in new_filters
         self.assertEqual(set(old_filters), set(new_filters))
-
 
     def test_warnings_are_shown(self):
         import warnings

--- a/src/zope/testrunner/tests/test_subunit.py
+++ b/src/zope/testrunner/tests/test_subunit.py
@@ -24,7 +24,7 @@ from zope.testrunner import formatter
 try:
     unichr
 except NameError:
-    unichr = chr # Python 3
+    unichr = chr  # Python 3
 
 
 try:

--- a/src/zope/testrunner/tests/testrunner-colors.rst
+++ b/src/zope/testrunner/tests/testrunner-colors.rst
@@ -95,7 +95,7 @@ A failed test run highlights the failures in red:
     {red}      File "testrunner-ex/sample2/sampletests_e.py", line 19, in f{normal}
     {red}        g(){normal}
     {red}      File "testrunner-ex/sample2/sampletests_e.py", line 24, in g{normal}
-    {red}        x = y + 1{normal}
+    {red}        x = y + 1  # noqa: F821{normal}
     {red}       - __traceback_info__: I don't know what Y should be.{normal}
     {red}    NameError: global name 'y' is not defined{normal}
     <BLANKLINE>
@@ -110,7 +110,7 @@ A failed test run highlights the failures in red:
     {normal}  File "{boldblue}testrunner-ex/sample2/sampletests_e.py{normal}", line {boldred}19{normal}, in {boldcyan}f{normal}
     {cyan}    g(){normal}
     {normal}  File "{boldblue}testrunner-ex/sample2/sampletests_e.py{normal}", line {boldred}24{normal}, in {boldcyan}g{normal}
-    {cyan}    x = y + 1{normal}
+    {cyan}    x = y + 1  # noqa: F821{normal}
     {red}   - __traceback_info__: I don't know what Y should be.{normal}
     {red}NameError: global name 'y' is not defined{normal}
     <BLANKLINE>
@@ -141,7 +141,7 @@ A failed test run highlights the failures in red:
     {normal}  File "{boldblue}unittest.py{normal}", line {boldred}260{normal}, in {boldcyan}run{normal}
     {cyan}    testMethod(){normal}
     {normal}  File "{boldblue}testrunner-ex/sample2/sampletests_f.py{normal}", line {boldred}21{normal}, in {boldcyan}test{normal}
-    {cyan}    self.assertEqual(1,0){normal}
+    {cyan}    self.assertEqual(1, 0){normal}
     {normal}  File "{boldblue}unittest.py{normal}", line {boldred}333{normal}, in {boldcyan}failUnlessEqual{normal}
     {cyan}    raise self.failureException, \{normal}
     {red}AssertionError: 1 != 0{normal}

--- a/src/zope/testrunner/tests/testrunner-debugging.rst
+++ b/src/zope/testrunner/tests/testrunner-debugging.rst
@@ -36,7 +36,7 @@ runner will enter pdb at that point:
     Running zope.testrunner.layer.UnitTests tests:
     ...
     > testrunner-ex/sample3/sampletests_d.py(27)test_set_trace1()
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) p x
     1
     (Pdb) c

--- a/src/zope/testrunner/tests/testrunner-edge-cases.rst
+++ b/src/zope/testrunner/tests/testrunner-edge-cases.rst
@@ -93,7 +93,7 @@ Using pdb.set_trace in a function called by an ordinary test:
     ... # doctest: +ELLIPSIS
     Running zope.testrunner.layer.UnitTests tests:...
     > testrunner-ex/sample3/sampletests_d.py(47)f()
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) p x
     1
     (Pdb) c
@@ -111,11 +111,11 @@ Using pdb.set_trace in a function called by a doctest in a doc string:
     Running zope.testrunner.layer.UnitTests tests:
       Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
     > testrunner-ex/sample3/sampletests_d.py(NNN)f()
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) n
     --Return--
     > ...->None
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) p x
     1
     (Pdb) c
@@ -182,11 +182,11 @@ Using pdb.set_trace in a function called by a doctest in a doc file:
     Running zope.testrunner.layer.UnitTests tests:
       Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
     > testrunner-ex/sample3/sampletests_d.py(NNN)f()
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) n
     --Return--
     > ...->None
-    -> y = x
+    -> y = x  # noqa: F841
     (Pdb) p x
     1
     (Pdb) c

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -47,7 +47,7 @@ be read only):
           File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
             g()
           File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-            x = y + 1
+            x = y + 1  # noqa: F821
            - __traceback_info__: I don't know what Y should be.
         NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -60,7 +60,7 @@ be read only):
       File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
         g()
       File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-        x = y + 1
+        x = y + 1  # noqa: F821
        - __traceback_info__: I don't know what Y should be.
     NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -89,7 +89,7 @@ be read only):
     Failure in test test (sample2.sampletests_f.Test)
     Traceback (most recent call last):
       File "testrunner-ex/sample2/sampletests_f.py", line 21, in test
-        self.assertEqual(1,0)
+        self.assertEqual(1, 0)
       File "/usr/local/python/2.3/lib/python2.3/unittest.py", line 302, in failUnlessEqual
         raise self.failureException, \
     AssertionError: 1 != 0
@@ -133,7 +133,7 @@ there'll be a summary of the errors at the end of the test:
           File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
             g()
           File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-            x = y + 1
+            x = y + 1  # noqa: F821
            - __traceback_info__: I don't know what Y should be.
         NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -147,7 +147,7 @@ there'll be a summary of the errors at the end of the test:
       File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
         g()
       File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-        x = y + 1
+        x = y + 1  # noqa: F821
        - __traceback_info__: I don't know what Y should be.
     NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -176,7 +176,7 @@ there'll be a summary of the errors at the end of the test:
     Failure in test test (sample2.sampletests_f.Test)
     Traceback (most recent call last):
       File "testrunner-ex/sample2/sampletests_f.py", line 21, in test
-        self.assertEqual(1,0)
+        self.assertEqual(1, 0)
       File ".../unittest.py", line 302, in failUnlessEqual
         raise self.failureException, \
     AssertionError: 1 != 0
@@ -223,7 +223,7 @@ Similarly for progress output, the progress ticker will be interrupted:
           File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
             g()
           File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-            x = y + 1
+            x = y + 1  # noqa: F821
            - __traceback_info__: I don't know what Y should be.
         NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -240,7 +240,7 @@ Similarly for progress output, the progress ticker will be interrupted:
       File "testrunner-ex/sample2/sampletests_e.py", line 19, in f
         g()
       File "testrunner-ex/sample2/sampletests_e.py", line 24, in g
-        x = y + 1
+        x = y + 1  # noqa: F821
        - __traceback_info__: I don't know what Y should be.
     NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -273,7 +273,7 @@ Similarly for progress output, the progress ticker will be interrupted:
     Failure in test test (sample2.sampletests_f.Test)
     Traceback (most recent call last):
       File "testrunner-ex/sample2/sampletests_f.py", line 21, in test
-        self.assertEqual(1,0)
+        self.assertEqual(1, 0)
       File ".../unittest.py", line 302, in failUnlessEqual
         raise self.failureException, \
     AssertionError: 1 != 0
@@ -821,7 +821,7 @@ Then run the tests:
     <BLANKLINE>
     Traceback (most recent call last):
       File "testrunner-ex/sample2/sample21/sampletests_i.py", line 15, in ?
-        import zope.testrunner.huh
+        import zope.testrunner.huh  # noqa: F401
     ImportError: No module named huh
     <BLANKLINE>
     <BLANKLINE>

--- a/src/zope/testrunner/tests/testrunner-ex-6/cwdtests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-6/cwdtests.py
@@ -1,8 +1,10 @@
 import unittest
 import os
 
+
 class Layer1:
     pass
+
 
 class Layer2:
     pass

--- a/src/zope/testrunner/tests/testrunner-ex-pp-lib/sample4/products/__init__.py
+++ b/src/zope/testrunner/tests/testrunner-ex-pp-lib/sample4/products/__init__.py
@@ -18,14 +18,13 @@ import os
 
 __path__.append(
     os.path.join(
-        os.path.dirname( # testing
-            os.path.dirname( # testrunner-ex-knit-lib
-                os.path.dirname( # sample4
-                    os.path.dirname(__file__) # products
+        os.path.dirname(  # testing
+            os.path.dirname(  # testrunner-ex-knit-lib
+                os.path.dirname(  # sample4
+                    os.path.dirname(__file__)  # products
                     )
                 )
-            )
-        , "testrunner-ex-pp-products"
+            ),
+        "testrunner-ex-pp-products"
         )
     )
-

--- a/src/zope/testrunner/tests/testrunner-ex-pp-products/more/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-pp-products/more/sampletests.py
@@ -14,12 +14,14 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     layer = 'samplelayers.Layer111'
 
     def test_another_test_in_products(self):
         pass
-        
+
+
 def test_suite():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-ex-pp-products/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-pp-products/sampletests.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     layer = 'samplelayers.Layer111'

--- a/src/zope/testrunner/tests/testrunner-ex-skip/sample_skipped_tests.py
+++ b/src/zope/testrunner/tests/testrunner-ex-skip/sample_skipped_tests.py
@@ -17,6 +17,7 @@ import unittest
 
 class TestSkipppedWithLayer(unittest.TestCase):
     layer = "sample_skipped_tests.Layer"
+
     @unittest.skip('Hop, skipped')
     def test_layer_skipped(self):
         pass

--- a/src/zope/testrunner/tests/testrunner-ex/gc0.py
+++ b/src/zope/testrunner/tests/testrunner-ex/gc0.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import doctest
 
+
 def make_sure_gc_is_disabled():
     """
     >>> import gc
@@ -20,6 +21,6 @@ def make_sure_gc_is_disabled():
     0
     """
 
+
 def test_suite():
     return doctest.DocTestSuite()
-

--- a/src/zope/testrunner/tests/testrunner-ex/gc1.py
+++ b/src/zope/testrunner/tests/testrunner-ex/gc1.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import doctest
 
+
 def make_sure_gc_threshold_is_one():
     """
     >>> import gc
@@ -20,6 +21,6 @@ def make_sure_gc_threshold_is_one():
     1
     """
 
+
 def test_suite():
     return doctest.DocTestSuite()
-

--- a/src/zope/testrunner/tests/testrunner-ex/gcset.py
+++ b/src/zope/testrunner/tests/testrunner-ex/gcset.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import doctest
 
+
 def make_sure_gc_threshold_is_701_11_9():
     """
     >>> import gc
@@ -20,6 +21,6 @@ def make_sure_gc_threshold_is_701_11_9():
     (701, 11, 9)
     """
 
+
 def test_suite():
     return doctest.DocTestSuite()
-

--- a/src/zope/testrunner/tests/testrunner-ex/gcstats.py
+++ b/src/zope/testrunner/tests/testrunner-ex/gcstats.py
@@ -13,6 +13,7 @@
 ##############################################################################
 import doctest
 
+
 def generate_some_gc_statistics():
     """
     >>> import gc
@@ -20,6 +21,6 @@ def generate_some_gc_statistics():
     >>> _ = gc.collect()
     """
 
+
 def test_suite():
     return doctest.DocTestSuite()
-

--- a/src/zope/testrunner/tests/testrunner-ex/leak.py
+++ b/src/zope/testrunner/tests/testrunner-ex/leak.py
@@ -12,22 +12,28 @@
 #
 ##############################################################################
 
-import unittest, time
+import time
+import unittest
+
 
 class ClassicLeakable:
     def __init__(self):
         self.x = 'x'
 
+
 class Leakable(object):
     def __init__(self):
         self.x = 'x'
 
+
 leaked = []
+
 
 class TestSomething(unittest.TestCase):
 
     def testleak(self):
         leaked.append((ClassicLeakable(), Leakable(), time.time()))
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/pledge.py
+++ b/src/zope/testrunner/tests/testrunner-ex/pledge.py
@@ -20,6 +20,7 @@ the natural resources of my %s.
 It's soils, minerals, forests, waters, and wildlife.
 """
 
+
 def pledge():
     """
     >>> def print_pledge():
@@ -32,7 +33,6 @@ def pledge():
     <BLANKLINE>
     """
 
+
 def test_suite():
     return doctest.DocTestSuite()
-
-

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sample11/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sample11/sampletests.py
@@ -15,23 +15,29 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestA3(unittest.TestCase):
 
@@ -40,29 +46,39 @@ class TestA3(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB2(unittest.TestCase):
     level = 2
@@ -70,13 +86,17 @@ class TestB2(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -84,13 +104,17 @@ class TestB2(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -99,6 +123,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -106,11 +131,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sample13/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sample13/sampletests.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test1.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test1.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test11.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test11.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer11'
 layer = samplelayers.Layer11
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test111.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test111.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer111'
 layer = samplelayers.Layer111
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test112.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test112.py
@@ -20,9 +20,10 @@ layername = 'samplelayers.Layer112'
 layer = samplelayers.Layer112
 
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -30,21 +31,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -52,17 +58,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -75,18 +85,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -98,6 +112,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -108,6 +123,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -116,6 +132,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test12.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test12.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer12'
 layer = samplelayers.Layer12
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test121.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test121.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer121'
 layer = samplelayers.Layer121
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test122.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test122.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer122'
 layer = samplelayers.Layer122
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test_one.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests/test_one.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_discover.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_discover.py
@@ -1,5 +1,6 @@
 import unittest
 
+
 class TestA(unittest.TestCase):
     def test_truth(self):
         self.assert_(True)

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_discover_notests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_discover_notests.py
@@ -1,2 +1,2 @@
-def test_function_that_would_never_be_run():
+def test_function_that_would_never_be_run(self):
     self.assert_(True)

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_none_suite.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_none_suite.py
@@ -14,5 +14,6 @@
 """Sample tests with a layer that can't be torn down
 """
 
+
 def test_suite():
     pass

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_none_test.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_none_test.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(None)

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_ntd.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_ntd.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+
 class Layer:
 
     def setUp(self):
@@ -25,6 +26,7 @@ class Layer:
     def tearDown(self):
         raise NotImplementedError
     tearDown = classmethod(tearDown)
+
 
 class TestSomething(unittest.TestCase):
 

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_ntds.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletests_ntds.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+
 class Layer:
 
     def setUp(self):
@@ -25,6 +26,7 @@ class Layer:
     def tearDown(self):
         raise NotImplementedError
     tearDown = classmethod(tearDown)
+
 
 class TestSomething(unittest.TestCase):
 

--- a/src/zope/testrunner/tests/testrunner-ex/sample1/sampletestsf.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample1/sampletestsf.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/badsyntax.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/badsyntax.py
@@ -13,4 +13,4 @@
 ##############################################################################
 
 # This is an intentional syntax error, to test module import errors.
-importx unittest
+importx unittest  # noqa: E999

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/do-not-enter/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/do-not-enter/sampletests.py
@@ -15,13 +15,15 @@
 import unittest
 import doctest
 
+
 def f():
     g()
+
 
 def g():
     x = 1
     x = x + 1
-    x = y + 1
+    x = y + 1  # noqa: F821
     x = x + 1
 
 
@@ -30,6 +32,7 @@ def eek(self):
     >>> f()
     1
     """
+
 
 class Test(unittest.TestCase):
 
@@ -47,6 +50,7 @@ class Test(unittest.TestCase):
 
     def test5(self):
         pass
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/donotenter/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/donotenter/sampletests.py
@@ -15,13 +15,15 @@
 import unittest
 import doctest
 
+
 def f():
     g()
+
 
 def g():
     x = 1
     x = x + 1
-    x = y + 1
+    x = y + 1  # noqa: F821
     x = x + 1
 
 
@@ -30,6 +32,7 @@ def eek(self):
     >>> f()
     1
     """
+
 
 class Test(unittest.TestCase):
 
@@ -47,6 +50,7 @@ class Test(unittest.TestCase):
 
     def test5(self):
         pass
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sample21/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sample21/sampletests.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sample21/sampletests_i.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sample21/sampletests_i.py
@@ -13,12 +13,14 @@
 ##############################################################################
 
 import unittest
-import zope.testrunner.huh
+import zope.testrunner.huh  # noqa: F401
+
 
 class Test(unittest.TestCase):
 
     def test(self):
-        self.assertEqual(1,0)
-        
+        self.assertEqual(1, 0)
+
+
 def test_suite():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sample22/sampletests_i.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sample22/sampletests_i.py
@@ -14,10 +14,12 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     def test(self):
-        self.assertEqual(1,0)
-        
+        self.assertEqual(1, 0)
+
+
 def test_suitex():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sample23/sampletests_i.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sample23/sampletests_i.py
@@ -14,12 +14,14 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     def test(self):
-        self.assertEqual(1,0)
+        self.assertEqual(1, 0)
 
     raise TypeError('eek')
+
 
 def test_suite():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests/test_1.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests/test_1.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests/testone.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests/testone.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_1.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_1.py
@@ -14,6 +14,7 @@
 
 import doctest
 
+
 def eek(self):
     """
     >>> x = y
@@ -24,6 +25,7 @@ def eek(self):
     >>> z = x + 1
 
     """
-        
+
+
 def test_suite():
     return doctest.DocTestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_e.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_e.py
@@ -15,14 +15,16 @@
 import unittest
 import doctest
 
+
 def f():
     g()
+
 
 def g():
     x = 1
     x = x + 1
     __traceback_info__ = "I don't know what Y should be."
-    x = y + 1
+    x = y + 1  # noqa: F821
     x = x + 1
 
 
@@ -31,6 +33,7 @@ def eek(self):
     >>> f()
     1
     """
+
 
 class Test(unittest.TestCase):
 
@@ -48,6 +51,7 @@ class Test(unittest.TestCase):
 
     def test5(self):
         pass
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_f.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_f.py
@@ -14,10 +14,12 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     def test(self):
-        self.assertEqual(1,0)
+        self.assertEqual(1, 0)
+
 
 def test_suite():
     return unittest.makeSuite(Test)

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntd.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntd.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+
 class Layer:
 
     def setUp(self):
@@ -25,6 +26,7 @@ class Layer:
     def tearDown(self):
         raise NotImplementedError
     tearDown = classmethod(tearDown)
+
 
 class TestSomething(unittest.TestCase):
 

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntds.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/sampletests_ntds.py
@@ -17,6 +17,7 @@
 import unittest
 import doctest
 
+
 class Layer:
 
     def setUp(self):
@@ -26,6 +27,7 @@ class Layer:
     def tearDown(self):
         raise NotImplementedError
     tearDown = classmethod(tearDown)
+
 
 class TestSomething(unittest.TestCase):
 
@@ -46,8 +48,10 @@ class TestSomething(unittest.TestCase):
     def test_something5(self):
         f()
 
+
 def f():
     import pdb; pdb.set_trace()
+
 
 def test_set_trace():
     """
@@ -55,7 +59,8 @@ def test_set_trace():
     ...     x = 1
     ...     import pdb; pdb.set_trace()
     """
-    
+
+
 def test_set_trace2():
     """
     >>> f()

--- a/src/zope/testrunner/tests/testrunner-ex/sample2/stderrtest.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample2/stderrtest.py
@@ -19,7 +19,6 @@ import doctest
 import sys
 
 
-
 class Layer:
 
     def setUp(self):

--- a/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py
@@ -14,18 +14,19 @@
 import unittest
 import doctest
 
+
 class TestSomething(unittest.TestCase):
 
     def test_set_trace1(self):
         x = 1
         import pdb; pdb.set_trace()
-        y = x
+        y = x  # noqa: F841
 
     def test_set_trace2(self):
         f()
 
     def test_post_mortem1(self):
-        x = 1
+        x = 1  # noqa: F841
         raise ValueError
 
     def test_post_mortem2(self):
@@ -36,14 +37,17 @@ class TestSomething(unittest.TestCase):
         y = 2
         assert x == y
 
+
 def f():
     x = 1
     import pdb; pdb.set_trace()
-    y = x
+    y = x  # noqa: F841
+
 
 def g():
-    x = 1
+    x = 1  # noqa: F841
     raise ValueError
+
 
 def set_trace3(self):
     """
@@ -53,16 +57,19 @@ def set_trace3(self):
     ...     y = x
     """
 
+
 def set_trace4(self):
     """
     >>> f()
     """
+
 
 def post_mortem3(self):
     """
     >>> x = 1
     >>> raise ValueError
     """
+
 
 def post_mortem4(self):
     """
@@ -88,6 +95,7 @@ def test_suite():
         doctest.DocFileSuite('post_mortem6.rst'),
         doctest.DocFileSuite('post_mortem_failure.rst'),
         ))
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')

--- a/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_ntd.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_ntd.py
@@ -16,6 +16,7 @@
 
 import unittest
 
+
 class Layer:
 
     def setUp(self):
@@ -25,6 +26,7 @@ class Layer:
     def tearDown(self):
         raise NotImplementedError
     tearDown = classmethod(tearDown)
+
 
 class TestSomething(unittest.TestCase):
 

--- a/src/zope/testrunner/tests/testrunner-ex/samplelayers.py
+++ b/src/zope/testrunner/tests/testrunner-ex/samplelayers.py
@@ -14,8 +14,9 @@
 """Sample test layers
 """
 
-layer = '0' # Internal to samples. Not part of layer API
+layer = '0'  # Internal to samples. Not part of layer API
 layerx = '0'
+
 
 class Layer1:
     # Internal to samples. Not part of layer API:
@@ -37,8 +38,9 @@ class Layer1:
         layer = self.base
     tearDown = classmethod(tearDown)
 
+
 class Layerx:
-    layerx = '1' # Internal to samples. Not part of layer API
+    layerx = '1'  # Internal to samples. Not part of layer API
     basex = '0'
 
     def setUp(self):
@@ -55,18 +57,21 @@ class Layerx:
         layerx = self.basex
     tearDown = classmethod(tearDown)
 
+
 class Layer11(Layer1):
-    layer = '11' # Internal to samples. Not part of layer API
-    base  = '1'  # Internal to samples. Not part of layer API
+    layer = '11'  # Internal to samples. Not part of layer API
+    base = '1'    # Internal to samples. Not part of layer API
+
 
 class Layer12(Layer1):
-    layer = '12' # Internal to samples. Not part of layer API
-    base  = '1'  # Internal to samples. Not part of layer API
+    layer = '12'  # Internal to samples. Not part of layer API
+    base = '1'    # Internal to samples. Not part of layer API
+
 
 class Layer111(Layerx, Layer11):
-    layer = '111' # Internal to samples. Not part of layer API
-    base  = '11'  # Internal to samples. Not part of layer API
-    layerx = '2' # Internal to samples. Not part of layer API
+    layer = '111'  # Internal to samples. Not part of layer API
+    base = '11'    # Internal to samples. Not part of layer API
+    layerx = '2'   # Internal to samples. Not part of layer API
     basex = '1'
 
     def setUp(self):
@@ -90,15 +95,17 @@ class Layer111(Layerx, Layer11):
             raise ValueError("Bad layerx, %s, for %s." % (layerx, self))
         layerx = self.basex
     tearDown = classmethod(tearDown)
+
 
 class Layer121(Layer12):
-    layer = '121' # Internal to samples. Not part of layer API
-    base  = '12'  # Internal to samples. Not part of layer API
+    layer = '121'  # Internal to samples. Not part of layer API
+    base = '12'    # Internal to samples. Not part of layer API
+
 
 class Layer112(Layerx, Layer11):
-    layer = '112' # Internal to samples. Not part of layer API
-    base  = '11'  # Internal to samples. Not part of layer API
-    layerx = '2' # Internal to samples. Not part of layer API
+    layer = '112'  # Internal to samples. Not part of layer API
+    base = '11'    # Internal to samples. Not part of layer API
+    layerx = '2'   # Internal to samples. Not part of layer API
     basex = '1'
 
     def setUp(self):
@@ -123,6 +130,7 @@ class Layer112(Layerx, Layer11):
         layerx = self.basex
     tearDown = classmethod(tearDown)
 
+
 class Layer122(Layer12):
-    layer = '122' # Internal to samples. Not part of layer API
-    base  = '12'  # Internal to samples. Not part of layer API
+    layer = '122'  # Internal to samples. Not part of layer API
+    base = '12'    # Internal to samples. Not part of layer API

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test1.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test1.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test11.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test11.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer11'
 layer = samplelayers.Layer11
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test111.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test111.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer111'
 layer = samplelayers.Layer111
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test112.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test112.py
@@ -20,9 +20,10 @@ layername = 'samplelayers.Layer112'
 layer = samplelayers.Layer112
 
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -35,14 +36,17 @@ class TestA(unittest.TestCase):
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -52,23 +56,28 @@ class TestA(unittest.TestCase):
         # that are set in setUp but not cleared in tearDown.
         self.assertEqual(self.clean, 1)
 
+
 class TestB(unittest.TestCase):
     layer = layername
 
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -81,18 +90,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -104,6 +117,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -114,6 +128,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -122,6 +137,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test12.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test12.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer12'
 layer = samplelayers.Layer12
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test121.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test121.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer121'
 layer = samplelayers.Layer121
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test122.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test122.py
@@ -19,9 +19,10 @@ import samplelayers
 layername = 'samplelayers.Layer122'
 layer = samplelayers.Layer122
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     layer = layername
@@ -29,21 +30,26 @@ class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 class TestB(unittest.TestCase):
     layer = layername
@@ -51,17 +57,21 @@ class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, layer.layer)
@@ -74,18 +84,22 @@ class TestNotMuch(unittest.TestCase):
     def test_1(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, layer.layer)
         self.assertEqual(samplelayers.layerx, layer.layerx)
+
 
 def setUp(test):
     test.globs['z'] = 1
     test.globs['layer'] = layer.layer
     test.globs['layerx'] = layer.layerx
     test.globs['samplelayers'] = samplelayers
+
 
 def test_y0(self):
     """
@@ -97,6 +111,7 @@ def test_y0(self):
     (True, True)
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -107,6 +122,7 @@ def test_x0(self):
     (True, True)
     """
 
+
 def test_z1(self):
     """
     >>> z
@@ -115,6 +131,7 @@ def test_z1(self):
     >>> (layer == samplelayers.layer), (layerx == samplelayers.layerx)
     (True, True)
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests/test_one.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests/test_one.py
@@ -15,35 +15,45 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -51,13 +61,17 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
+
 def setUp(test):
     test.globs['z'] = 1
+
 
 def test_y0(self):
     """
@@ -66,6 +80,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -73,11 +88,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/sampletests_buffering.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletests_buffering.py
@@ -14,7 +14,9 @@
 """Sample tests with sleep and layers that can't be torn down
 """
 
-import unittest, time
+import time
+import unittest
+
 
 class Layer1:
 

--- a/src/zope/testrunner/tests/testrunner-ex/sampletestsf.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sampletestsf.py
@@ -15,23 +15,32 @@
 import unittest
 import doctest
 
-x=0
-y=0
-z=0
+import samplelayers
+
+
+x = 0
+y = 0
+z = 0
+
 
 class TestA(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestA2(unittest.TestCase):
     level = 2
@@ -39,27 +48,36 @@ class TestA2(unittest.TestCase):
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
+
     def test_y0(self):
         self.assertEqual(y, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
+
 
 class TestB(unittest.TestCase):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
+
     def test_x0(self):
         self.assertEqual(x, 0)
+
     def test_z0(self):
         self.assertEqual(z, 0)
 
@@ -67,8 +85,10 @@ class TestB(unittest.TestCase):
 class TestNotMuch(unittest.TestCase):
     def test_1(self):
         pass
+
     def test_2(self):
         pass
+
     def test_3(self):
         pass
 
@@ -84,6 +104,7 @@ def test_y0(self):
     0
     """
 
+
 def test_x0(self):
     """
     >>> x = 0
@@ -91,13 +112,13 @@ def test_x0(self):
     0
     """
 
+
 def test_z1(self):
     """
     >>> z
     1
     """
 
-import samplelayers
 
 class Layered:
 
@@ -105,42 +126,52 @@ class Layered:
     layerv = '1'
     layerx = '0'
 
+
 class TestA1(unittest.TestCase, Layered):
 
     def setUp(self):
         global x
         x = 1
+
     def tearDown(self):
         global x
         x = 0
+
     def test_x1(self):
         self.assertEqual(x, 1)
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_y0(self):
         self.assertEqual(y, 0)
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
 
+
 class TestB1(unittest.TestCase, Layered):
     def setUp(self):
         global y
         y = 1
+
     def tearDown(self):
         global y
         y = 0
+
     def test_y1(self):
         self.assertEqual(y, 1)
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_x0(self):
         self.assertEqual(x, 0)
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_z0(self):
         self.assertEqual(z, 0)
         self.assertEqual(samplelayers.layer, self.layerv)
@@ -151,13 +182,14 @@ class TestNotMuch1(unittest.TestCase, Layered):
     def test_1(self):
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_2(self):
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
+
     def test_3(self):
         self.assertEqual(samplelayers.layer, self.layerv)
         self.assertEqual(samplelayers.layerx, self.layerx)
-
 
 
 def test_suite():

--- a/src/zope/testrunner/tests/testrunner-ex/unicode.py
+++ b/src/zope/testrunner/tests/testrunner-ex/unicode.py
@@ -14,5 +14,6 @@
 
 import doctest
 
+
 def test_suite():
     return doctest.DocFileSuite('unicode.rst')

--- a/src/zope/testrunner/tests/testrunner-ex/usecompiled/compiletest.py
+++ b/src/zope/testrunner/tests/testrunner-ex/usecompiled/compiletest.py
@@ -14,12 +14,15 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     def test1(self):
         self.assertEqual(1, 1)
+
     def test2(self):
         self.assertEqual(1, 1)
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-ex/usecompiled/package/compiletest.py
+++ b/src/zope/testrunner/tests/testrunner-ex/usecompiled/package/compiletest.py
@@ -14,12 +14,15 @@
 
 import unittest
 
+
 class Test(unittest.TestCase):
 
     def test1(self):
         self.assertEqual(1, 1)
+
     def test2(self):
         self.assertEqual(1, 1)
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -233,7 +233,7 @@ https://bugs.launchpad.net/subunit/+bug/1740158.)
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
             g()
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
-            x = y + 1
+            x = y + 1  # noqa: F821
            - __traceback_info__: I don't know what Y should be.
         NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -254,7 +254,7 @@ https://bugs.launchpad.net/subunit/+bug/1740158.)
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
         g()
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
-        x = y + 1
+        x = y + 1  # noqa: F821
        - __traceback_info__: I don't know what Y should be.
     NameError: global name 'y' is not defined
     <BLANKLINE>
@@ -441,7 +441,7 @@ Let's run tests including a module with some bad syntax:
     traceback (text/x-traceback...)
     Traceback (most recent call last):
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
-        importx unittest
+        importx unittest  # noqa: E999
                        ^
     SyntaxError: invalid syntax
     <BLANKLINE>
@@ -451,7 +451,7 @@ Let's run tests including a module with some bad syntax:
     traceback (text/x-traceback...)
     Traceback (most recent call last):
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample21/sampletests_i.py", line 16, in <module>
-        import zope.testrunner.huh
+        import zope.testrunner.huh  # noqa: F401
     ImportError: No module named huh
     <BLANKLINE>
     id=sample2.sample21.sampletests_i status=fail tags=(zope:import_error)

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -207,7 +207,7 @@ Errors are recorded in the subunit stream as MIME-encoded chunks of text.
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
             g()
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
-            x = y + 1
+            x = y + 1  # noqa: F821
            - __traceback_info__: I don't know what Y should be.
         NameError: global name 'y' is not defined
     0\r
@@ -235,7 +235,7 @@ Errors are recorded in the subunit stream as MIME-encoded chunks of text.
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in f
         g()
      testrunner-ex/sample2/sampletests_e.py", Line NNN, in g
-        x = y + 1
+        x = y + 1  # noqa: F821
        - __traceback_info__: I don't know what Y should be.
     NameError: global name 'y' is not defined
     0\r
@@ -474,7 +474,7 @@ Let's run tests including a module with some bad syntax:
     error: sample2.badsyntax [
     Traceback (most recent call last):
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
-        importx unittest
+        importx unittest  # noqa: E999
                        ^
     SyntaxError: invalid syntax
     ]
@@ -483,7 +483,7 @@ Let's run tests including a module with some bad syntax:
     error: sample2.sample21.sampletests_i [
     Traceback (most recent call last):
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/sample21/sampletests_i.py", line 16, in <module>
-        import zope.testrunner.huh
+        import zope.testrunner.huh  # noqa: F401
     ImportError: No module named huh
     ]
     test: sample2.sample23.sampletests_i

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,py,35,36,37,38}{,-subunit},coverage,docs
+    py{27,py,35,36,37,38}{,-subunit},coverage,lint,docs
 
 [testenv]
 extras =
@@ -24,6 +24,14 @@ extras =
     subunit
 deps =
     coverage
+
+[testenv:lint]
+basepython = python3
+skip_install = true
+deps =
+    flake8
+commands =
+    flake8 src setup.py
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
I added a few things to `per-file-ignores` where it seemed that making
`flake8` happy with them directly would involve making the code less
readable or idiomatic, but most of this is just an enormous pile of
whitespace changes and similar.

In practice there should be no functional change as a result of this
commit.  The only things I can think of seem extremely unlikely, and can
only affect Python 2:

 * On Python 2, changing bare `except:` to `except BaseException:` could
   conceivably break somebody relying on being able to raise an instance
   of an old-style class as an exception (but this will break on Python
   3 anyway);

 * Changing `if t is types.InstanceType:` to `if issubclass(t,
   types.InstanceType):` could perhaps change behaviour for some very
   strange code (but `TrackRefs.update` can't possibly work on Python 3
   at the moment anyway, since `types.InstanceType` doesn't exist
   there).

All `tox` environments pass locally.