### PR TITLE
Configuring for pure-python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "c90811ca98ae13a1a52890c1e28bcf436b5a11dc"
+commit-id = "af622790bf7aa724913c1929effe5992f422d175"
 
 [python]
 with-appveyor = true
@@ -40,10 +40,13 @@ additional-config = [
 additional-envlist = [
     "py{27,35,36,37,38,39,py,py3}-subunit",
     ]
+testenv-deps = [
+    ]
 testenv-additional-extras = [
     "subunit: subunit",
     "coverage: subunit",
     ]
+use-flake8 = true
 
 [github-actions]
 additional-config = [

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ envlist =
 [testenv]
 usedevelop = true
 deps =
-    zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -56,7 +55,6 @@ allowlist_externals =
 deps =
     coverage
     coverage-python-version
-    zope.testrunner
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
Newer template: builds all branches, drops self-dependency on zope.testrunner in tox.ini.