### PR TITLE
do not disable existing loggers during logsupport initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 5.3.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Do not disable existing loggers during logsupport initialization
+  (`#120 <https://github.com/zopefoundation/zope.testrunner/pull/120>`_).
+
 
 
 5.3.0 (2021-03-17)

--- a/src/zope/testrunner/logsupport.py
+++ b/src/zope/testrunner/logsupport.py
@@ -39,7 +39,7 @@ class Logging(zope.testrunner.feature.Feature):
 
         logini = os.path.abspath("log.ini")
         if os.path.exists(logini):
-            logging.config.fileConfig(logini)
+            logging.config.fileConfig(logini, disable_existing_loggers=False)
         else:
             # If there's no log.ini, cause the logging package to be
             # silent during testing.


### PR DESCRIPTION
fixes #120.

`logsupport.Logging` used to call `logging.config.fileConfig` without the `disable_existing_loggers` parameter (which defaults to `True`). This caused to disable loggers implicitly created during earlier initialization steps. When a test used one of those loggers, the test could fail (because it does not expect the logger to be disabled).

This PR calls `fileConfig` with `disable_existing_loggers=False`. All loggers existing at that time have been implicitly created in earlier `testrunner` initialization steps and therefore come from common libraries; it properly designed, they will not have associated handlers and defer to higher up loggers under application configuration control. Therefore, it does not harm to leave them enabled.