### PR TITLE
improve `--help` documentation for `--package-path` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 5.3.1 (unreleased)
 ==================
 
+- Improve ``--help`` documentation for ``--package-path`` option
+  (`#121 <https://github.com/zopefoundation/zope.testrunner/pull/121>`_).
+
 - Do not disable existing loggers during logsupport initialization
   (`#120 <https://github.com/zopefoundation/zope.testrunner/pull/120>`_).
 

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -418,14 +418,14 @@ will be run.
 
 setup.add_argument(
     '--package-path', action="append", dest='package_path', nargs=2,
+    metavar="ARG",
     help="""\
 Specify a path to be searched for tests, but not added to the Python
 search path.  Also specify a package for files found in this path.
 This is used to deal with directories that are stitched into packages
 that are not otherwise searched for tests.
 
-This option takes 2 arguments.  The first is a path name. The second is
-the package name.
+This option takes 2 arguments specifying the path and the package.
 
 This option can be used multiple times to specify
 multiple search paths.  The path is usually specified by the


### PR DESCRIPTION
fixes #121.

This PR (slightly) improves the documentation for option `--package-path` output by `-h/--help` by specifying `metavar="ARG"` and some rewording of the usage text.

