### PR TITLE
Adapt to python 3.10 SyntaxError messages

### DIFF
--- a/src/zope/testrunner/tests/testrunner-debugging-import-failure.rst
+++ b/src/zope/testrunner/tests/testrunner-debugging-import-failure.rst
@@ -41,7 +41,7 @@ Post-mortem debugging also works when there is an import failure.
       File ".../TESTS-DIR/tests.py", line 2
         impot doctest
                     ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax...
     > ...find.py(399)import_name()
     -> __import__(name)
     (Pdb) c

--- a/src/zope/testrunner/tests/testrunner-errors.rst
+++ b/src/zope/testrunner/tests/testrunner-errors.rst
@@ -818,7 +818,7 @@ Then run the tests:
       File "testrunner-ex/sample2/sampletests_i.py", line 1
         importx unittest
                        ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax...
     <BLANKLINE>
     <BLANKLINE>
     Module: sample2.sample21.sampletests_i

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -447,7 +447,7 @@ Let's run tests including a module with some bad syntax:
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
         importx unittest  # noqa: E999
                        ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax...
     <BLANKLINE>
     id=sample2.badsyntax status=fail tags=(zope:import_error)
     id=sample2.sample21.sampletests_i status=inprogress

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -480,7 +480,7 @@ Let's run tests including a module with some bad syntax:
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
         importx unittest  # noqa: E999
                        ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax...
     ]
     test: sample2.sample21.sampletests_i
     tags: zope:import_error


### PR DESCRIPTION
SyntaxError messages are becoming more verbose in python 3.10.  See https://docs.python.org/3.10/whatsnew/3.10.html#better-error-messages.  As a result, 4 tests fail with the current python 3.10 beta.  See https://bugzilla.redhat.com/show_bug.cgi?id=1958894 for the Fedora bug report.

With this change, the tests pass with both python 3.9 and 3.10 beta 1.