### PR TITLE
Fix tests with testtools >= 2.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 - Do not disable existing loggers during logsupport initialization
   (`#120 <https://github.com/zopefoundation/zope.testrunner/pull/120>`_).
 
+- Fix tests with testtools >= 2.5.0 (`#125
+  <https://github.com/zopefoundation/zope.testrunner/issues/125>`_).
 
 
 5.3.0 (2021-03-17)

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -442,8 +442,7 @@ Let's run tests including a module with some bad syntax:
     >>> subunit_summarize(testrunner.run_internal, defaults)
     id=sample2.badsyntax status=inprogress
     id=sample2.badsyntax
-    traceback (text/x-traceback...)
-    Traceback (most recent call last):
+    traceback (text/x-traceback...)...
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
         importx unittest  # noqa: E999
                        ^

--- a/src/zope/testrunner/tests/testrunner-subunit.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit.rst
@@ -475,8 +475,7 @@ Let's run tests including a module with some bad syntax:
     >>> testrunner.run_internal(defaults)
     test: sample2.badsyntax
     tags: zope:import_error
-    error: sample2.badsyntax [
-    Traceback (most recent call last):
+    error: sample2.badsyntax [...
       File "/home/benji/workspace/all-the-trunks/zope.testrunner/src/zope/testrunner/testrunner-ex/sample2/badsyntax.py", line 16
         importx unittest  # noqa: E999
                        ^


### PR DESCRIPTION
testtools 2.5.0 only supports Python 3, and so switched from traceback2
to the standard library's traceback.  However, this includes the fix for
https://bugs.python.org/issue24695, and so doesn't produce a traceback
header when there's no traceback, in particular for `SyntaxError`
exceptions.  Adjust the tests to tolerate this.

Fixes #125.