### PR TITLE
use `sys._current_frames` to detect new threads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 5.4.1 (unreleased)
 ==================
 
+- Use ``sys._current_frames`` (rather than ``threading.enumerate``)
+  as base for new thread detection, fixes
+  `#130 <https://github.com/zopefoundation/zope.testrunner/issues/130>`_.
+
 - New option ``--gc-after-test``. It calls for a garbage collection
   after each test and can be used to track down ``ResourceWarning``s
   and cyclic garbage.

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -32,6 +32,7 @@ import warnings
 from contextlib import contextmanager
 
 from six import StringIO
+from zope.testrunner import threadsupport
 from zope.testrunner.find import import_name
 from zope.testrunner.find import name_from_layer, _layer_name_cache
 from zope.testrunner.layer import UnitTests
@@ -953,7 +954,7 @@ class TestResult(unittest.TestResult):
 
         self.options.output.start_test(test, self.testsRun, self.count)
 
-        self._threads = threading.enumerate()
+        self._threads = threadsupport.enumerate()
         self._start_time = time.time()
 
         self._setUpStdStreams()
@@ -1069,7 +1070,7 @@ class TestResult(unittest.TestResult):
 
         # Did the test leave any new threads behind?
         new_threads = []
-        for t in threading.enumerate():
+        for t in threadsupport.enumerate():
             if t.is_alive() and t not in self._threads:
                 if not any([re.match(p, t.name)
                             for p in self.options.ignore_new_threads]):

--- a/src/zope/testrunner/tests/test_threadsupport.py
+++ b/src/zope/testrunner/tests/test_threadsupport.py
@@ -98,9 +98,9 @@ class Tests(TestCase):
         self.check_new_thread()
 
     def check_new_thread(self, name=None):
-        t1 = self._mk_thread(name and (name + "-1"))
+        self._mk_thread(name and (name + "-1"))
         threads = self.alive()
-        t2 = self._mk_thread(name and (name + "-2"))
+        self._mk_thread(name and (name + "-2"))
         new_threads = [p for p in self.alive() if p not in threads]
         self.assertEqual(len(new_threads), 1)
 
@@ -116,9 +116,3 @@ class Tests(TestCase):
         t.lock.release()
         sleep(0.01)
         self.assertEqual(self.alive(), [])
-        
-
-    
-    
-
-

--- a/src/zope/testrunner/tests/test_threadsupport.py
+++ b/src/zope/testrunner/tests/test_threadsupport.py
@@ -1,0 +1,124 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+from threading import Lock, Thread, _start_new_thread
+from time import sleep
+from unittest import TestCase, skipUnless
+
+from ..threadsupport import current_frames, enumerate
+
+
+class ThreadMixin(object):
+    """test thread."""
+    def __init__(self):
+        self.lock = Lock()
+        self.stopped = False
+
+    def run(self):
+        with self.lock:
+            pass
+        self.stopped = True
+
+
+class ThrThread(ThreadMixin, Thread):
+    """``threading.Thread`` thread."""
+    def __init__(self, name):
+        Thread.__init__(self, name=name)
+        ThreadMixin.__init__(self)
+
+
+class DummyThread(ThreadMixin):
+    def start(self):
+        _start_new_thread(self.run, ())
+
+
+class Tests(TestCase):
+    def setUp(self):
+        self._threads = []
+        self._prethreads = enumerate()
+
+    def tearDown(self):
+        for t in self._threads:
+            if not t.stopped:
+                t.lock.release()
+                sleep(0.01)
+
+    def _mk_thread(self, name=None):
+        """create a new thread and start it.
+
+        Use a full thread if *name*; otherwise a dummy thread.
+        """
+        t = ThrThread(name) if name else DummyThread()
+        t.lock.acquire()
+        t.start()
+        self._threads.append(t)
+        sleep(0.01)
+        return t
+
+    def alive(self):
+        """alive threads not in ``_prethreads``."""
+        return [p for p in enumerate()
+                if p.is_alive() and p not in self._prethreads]
+
+    def test_thr_proxy(self):
+        self.check_proxy("Test ThrThread")
+
+    @skipUnless(current_frames, "no `current_frames`")
+    def test_dummy_proxy(self):
+        self.check_proxy()
+
+    def check_proxy(self, name=None):
+        t = self._mk_thread(name)
+        prs = self.alive()
+        self.assertEqual(len(prs), 1)
+        pr = prs[0]
+        self.assertTrue(pr.is_alive())
+        if name is None:
+            self.assertTrue(pr.name.startswith("Dummy-"))
+            self.assertIn("DummyThread", repr(pr))
+        else:
+            self.assertEqual(pr.name, t.name)
+            self.assertEqual(repr(pr), repr(t))
+
+    def test_thr_new_thread(self):
+        self.check_new_thread("Test ThrThread")
+
+    @skipUnless(current_frames, "no `current_frames`")
+    def test_dummy_new_thread(self):
+        self.check_new_thread()
+
+    def check_new_thread(self, name=None):
+        t1 = self._mk_thread(name and (name + "-1"))
+        threads = self.alive()
+        t2 = self._mk_thread(name and (name + "-2"))
+        new_threads = [p for p in self.alive() if p not in threads]
+        self.assertEqual(len(new_threads), 1)
+
+    def test_thr_stopped(self):
+        self.check_stopped("Test ThrThread")
+
+    @skipUnless(current_frames, "no `current_frames`")
+    def test_dummy_stopped(self):
+        self.check_stopped()
+
+    def check_stopped(self, name=None):
+        t = self._mk_thread(name)
+        t.lock.release()
+        sleep(0.01)
+        self.assertEqual(self.alive(), [])
+        
+
+    
+    
+
+

--- a/src/zope/testrunner/threadsupport.py
+++ b/src/zope/testrunner/threadsupport.py
@@ -33,7 +33,7 @@ else:
         th_known = dict((t.ident, t) for t in threading.enumerate())
         return [ThreadProxy(th_known[i] if i in th_known else DummyThread(i))
                 for i in running]
-    
+
 
 class ThreadProxy(object):
     """auxiliary class to provide ident based ``__eq__``."""
@@ -61,5 +61,3 @@ class DummyThread(object):
 
     def is_alive(self):
         return True
-
-

--- a/src/zope/testrunner/threadsupport.py
+++ b/src/zope/testrunner/threadsupport.py
@@ -1,0 +1,65 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Thread support beyond ``threading``.
+
+``threading.enumerate`` may or may not know threads
+started with ``_thread.start_new_thread``. If it knows them,
+it does not know when they stop.
+If ``sys._current_frames`` is available, use this to
+reliable determine the currently running threads.
+"""
+import sys
+import threading
+
+current_frames = getattr(sys, "_current_frames", None)
+
+if current_frames is None:  # pragma: no cover
+    enumerate = threading.enumerate
+else:
+    def enumerate():
+        """return sequence of proxies for the currently running threads."""
+        running = set(current_frames())
+        th_known = dict((t.ident, t) for t in threading.enumerate())
+        return [ThreadProxy(th_known[i] if i in th_known else DummyThread(i))
+                for i in running]
+    
+
+class ThreadProxy(object):
+    """auxiliary class to provide ident based ``__eq__``."""
+    def __init__(self, thread):
+        self.thread = thread
+
+    def __eq__(self, other):
+        return self.thread.ident == other.thread.ident
+
+    def __repr__(self):
+        return repr(self.thread)
+
+    def __getattr__(self, k):
+        return getattr(self.thread, k)
+
+
+class DummyThread(object):
+    """auxiliary to represent a thread unknown to ``threading``."""
+    def __init__(self, ident):
+        self.ident = ident
+        self.name = "Dummy-%s" % ident
+
+    def __repr__(self):
+        return "DummyThread %s, started, daemon" % self.ident
+
+    def is_alive(self):
+        return True
+
+


### PR DESCRIPTION
fixes #130.

This PR uses `sys._current_frames` (if available) as base for new thread detection.

In contrast to the formerly used `threading.enumerate`, `_current_frames` has reliable information about threads started via `_thread.start_new_thread`. This makes the runner's "new thread" information reliable even if  threads are started this way.