### PR TITLE
Fix: let `-at-level=level` with `level <= 0` run the tests at all levels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 5.6 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix: let ``--at-level=level`` with ``level <= 0`` run the tests
+  at all levels (rather than at no level)
+  `#138 <https://github.com/zopefoundation/zope.testrunner/issues/138>`_.
+  
 
 
 5.5 (2022-06-24)

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -468,7 +468,7 @@ def tests_from_suite(suite, options, dlevel=1,
                 duplicated_test_ids.add(suite_id)
             else:
                 seen_test_ids.add(suite_id)
-        if level <= options.at_level:
+        if options.at_level <= 0 or level <= options.at_level:
             if accept is None or accept(str(suite)):
                 yield (suite, layer)
 

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -135,7 +135,7 @@ searching.add_argument(
     default=1,
     help="""\
 Run the tests at the given level.  Any test at a level at or below
-this is run, any test at a level above this is not run.  Level 0
+this is run, any test at a level above this is not run.  Level <= 0
 runs all tests.
 """)
 


### PR DESCRIPTION
fixes #138.