### PR TITLE
Don't trigger post-mortem debugger for skipped tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
   Python 3.9 and removed in 3.11 (`#119
   <https://github.com/zopefoundation/zope.testrunner/issues/119>`_).
 
+- Don't trigger post mortem debugger for skipped tests. ( `#141
+  <https://github.com/zopefoundation/zope.testrunner/issues/141>`_).
+
 
 5.5.1 (2022-09-07)
 ==================

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -384,6 +384,8 @@ def run_tests(options, tests, name, failures, errors, skipped, import_errors):
                         test.debug()
                     except KeyboardInterrupt:
                         raise
+                    except unittest.SkipTest as e:
+                        result.addSkip(test, str(e))
                     except BaseException:
                         result.addError(
                             test,

--- a/src/zope/testrunner/tests/testrunner-debugging.rst
+++ b/src/zope/testrunner/tests/testrunner-debugging.rst
@@ -44,7 +44,7 @@ runner will enter pdb at that point:
     ...
     False
 
-Post-Mortem Dubigging
+Post-Mortem Debugging
 =====================
 
 You can also do post-mortem debugging, using the --post-mortem (-D)
@@ -107,6 +107,23 @@ converted to errors and can be debugged the same way:
     (Pdb) p y
     2
     (Pdb) c
+    Tearing down left over layers:
+      Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+    False
+
+
+Skipping tests with ``@unittest.skip`` decorator does not trigger the
+post-mortem debugger:
+
+    >>> sys.stdin = Input('q')
+    >>> sys.argv = ('test -ssample3 --tests-pattern ^sampletests_d$'
+    ...             ' -t skipped -D').split()
+    >>> try: testrunner.run_internal(defaults)
+    ... finally: sys.stdin = real_stdin
+    ... # doctest: +NORMALIZE_WHITESPACE +REPORT_NDIFF +ELLIPSIS
+    Running zope.testrunner.layer.UnitTests tests:
+      Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+      Ran 1 tests with 0 failures, 0 errors and 1 skipped in N.NNN seconds.
     Tearing down left over layers:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
     False

--- a/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py
+++ b/src/zope/testrunner/tests/testrunner-ex/sample3/sampletests_d.py
@@ -37,6 +37,10 @@ class TestSomething(unittest.TestCase):
         y = 2
         assert x == y
 
+    @unittest.skip("skipped test")
+    def test_skipped(self):
+        self.fail('test should have been skipped')
+
 
 def f():
     x = 1


### PR DESCRIPTION
Fixes #141 