### PR TITLE
Update code and tests to `python-subunit >= 1.4.3`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 6.2 (unreleased)
 ================
 
+- Update code and tests to ``python-subunit >= 1.4.3`` thus requiring at least
+  this version.
+
 
 6.1 (2023-08-26)
 ================

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ TESTS_REQUIRE = [
 EXTRAS_REQUIRE = {
     'test': TESTS_REQUIRE,
     'subunit': [
-        'python-subunit >= 0.0.11',
+        'python-subunit >= 1.4.3',
         'testtools >= 0.9.30',
     ],
     'docs': [

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -766,7 +766,7 @@ class FakeTest:
 # dependency on subunit.
 try:
     import subunit
-    from subunit.iso8601 import Utc
+    from iso8601 import UTC
     subunit.StreamResultToBytes
 except (ImportError, AttributeError):
     subunit = None
@@ -880,7 +880,7 @@ class SubunitOutputFormatter:
 
     def __init__(self, options, stream=None):
         if subunit is None:
-            raise Exception('Requires subunit 0.0.11 or better')
+            raise Exception('Requires subunit 1.4.3 or better')
         if testtools is None:
             raise Exception('Requires testtools 0.9.30 or better')
         self.options = options
@@ -893,7 +893,7 @@ class SubunitOutputFormatter:
         # Used to track the last layer that was set up or torn down. Either
         # None or (layer_name, last_touched_time).
         self._last_layer = None
-        self.UTC = Utc()
+        self.UTC = UTC
         # Content types used in the output.
         self.TRACEBACK_CONTENT_TYPE = ContentType(
             'text', 'x-traceback', {'language': 'python', 'charset': 'utf8'})

--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -880,7 +880,7 @@ class SubunitOutputFormatter:
 
     def __init__(self, options, stream=None):
         if subunit is None:
-            raise Exception('Requires subunit 1.4.3 or better')
+            raise Exception('Requires python-subunit 1.4.3 or better')
         if testtools is None:
             raise Exception('Requires testtools 0.9.30 or better')
         self.options = options

--- a/src/zope/testrunner/tests/testrunner-subunit-v2.rst
+++ b/src/zope/testrunner/tests/testrunner-subunit-v2.rst
@@ -32,7 +32,7 @@ For easier doctesting, we use a helper that summarizes the output.
     ...                eof=False, mime_type=None, route_code=None,
     ...                timestamp=None):
     ...         if (test_id, file_name) == self._last_file:
-    ...             self.stream.write(file_bytes.decode('utf-8', 'replace'))
+    ...             self.stream.write(file_bytes.tobytes().decode('utf-8', 'replace'))
     ...             return
     ...         elif self._last_file is not None:
     ...             self.stream.write('\n')
@@ -49,7 +49,7 @@ For easier doctesting, we use a helper that summarizes the output.
     ...             self.stream.write('\n')
     ...         if file_name is not None:
     ...             self.stream.write('%s (%s)\n' % (file_name, mime_type))
-    ...             self.stream.write(file_bytes.decode('utf-8', 'replace'))
+    ...             self.stream.write(file_bytes.tobytes().decode('utf-8', 'replace'))
     ...             self._last_file = (test_id, file_name)
     ...         self.stream.flush()
 


### PR DESCRIPTION
`python-subunit` in version `1.4.3+` no longer vendors a copy of `iso8601`, see https://github.com/testing-cabal/subunit/commit/91b07aa67aa95514cb140b8bbf4c82276db52b80#diff-7ee66c4f1536ac84dc5bbff1b8312e2eef24b974b3e48a5c5c2bcfdf2eb8f3ce

See https://github.com/zopefoundation/zope.testrunner/actions/runs/6213435427/job/16864498025 for the test failures, which guide into the wrong direction.
