### PR TITLE
build badge reference updated from travis-ci to GHA

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@
         :target: https://pypi.org/project/zope.testrunner/
         :alt: Supported Python versions
 
-.. image:: https://travis-ci.org/zopefoundation/zope.testrunner.svg?branch=master
-        :target: https://travis-ci.org/zopefoundation/zope.testrunner
+.. image:: https://github.com/zopefoundation/zope.testrunner/actions/workflows/tests.yml/badge.svg
+        :target: https://github.com/zopefoundation/zope.testrunner/actions/workflows/tests.yml
 
 .. image:: https://coveralls.io/repos/github/zopefoundation/zope.testrunner/badge.svg?branch=master
         :target: https://coveralls.io/github/zopefoundation/zope.testrunner?branch=master


### PR DESCRIPTION
I have gone through the developer guidelines of Zope foundation. To my best knowledge, I have tried to make changes. This was done with regards to the [issue](https://github.com/zopefoundation/meta/issues/206) opened by @icemac 

Please let me know if there's anything I can do from my end.
Thanks 😃