### PR TITLE
WIP: Partial fix for Python 3.12

### DIFF
--- a/src/zope/testrunner/formatter.py
+++ b/src/zope/testrunner/formatter.py
@@ -52,7 +52,7 @@ class OutputFormatter:
 
     def __init__(self, options):
         self.options = options
-        self.last_width = 0
+        self.test_width = self.last_width = 0
         self.compute_max_width()
 
     progress = property(lambda self: self.options.progress)

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -1019,9 +1019,10 @@ class TestResult(unittest.TestResult):
         self.testTearDown()
         # Without clearing, cyclic garbage referenced by the test
         # would be reported in the following test.
-        test.__dict__.clear()
-        test.__dict__.update(self._test_state)
-        del self._test_state
+        if hasattr(self, '_test_state'):
+            test.__dict__.clear()
+            test.__dict__.update(self._test_state)
+            del self._test_state
         cycles = None
         if (uses_refcounts and self.options.gc_after_test and
                 self.options.verbose >= 4):
@@ -1052,9 +1053,10 @@ class TestResult(unittest.TestResult):
                 #       printed for every subsequent test.
 
         # Did the test leave any new threads behind?
+        old_threads = getattr(self, '_threads', ())
         new_threads = []
         for t in threadsupport.enumerate():
-            if t.is_alive() and t not in self._threads:
+            if t.is_alive() and t not in old_threads:
                 if not any([re.match(p, t.name)
                             for p in self.options.ignore_new_threads]):
                     new_threads.append(t)


### PR DESCRIPTION
Python 3.12 doesn't call `startTest()` for skipped tests, which caused AttributeErrors for things initialized in our `TestResult.startTest()` (and `OutputFormatter.start_test()`).

This is not a complete fix: there are still test failures because they expected "ran 1 tests, 1 skipped" and now get "ran 0 tests, 0 skipped". I don't know if we want to keep the old method of counting; it kind of makes sense to me not to count skipped tests as running ones.

I'm not sure how to fix that without adding sys.version_info >= (3, 12) checks everywhere.

See #157 and https://github.com/python/cpython/issues/106584.