### PR TITLE
work around Python 3.12 no longer calling `startTest` for skipped tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 6.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Work around Python 3.12 no longer calling ``startTest`` for skipped tests
+  (`#157 <https://github.com/zopefoundation/zope.testrunner/issues/157>_`).
 
 
 6.2 (2023-11-08)

--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -950,7 +950,17 @@ class TestResult(unittest.TestResult):
         self.options.output.test_success(test, t)
 
     def addSkip(self, test, reason):
-        self._restoreStdStreams()
+        if not hasattr(self, "_test_state"):
+            # ``startTest`` was not called -- set up extected state
+            self._test_state = test.__dict__
+            count = test.countTestCases()
+            self.testsRun += count
+            self.options.output.start_test(test, self.testsRun, self.count)
+            self._threads = threadsupport.enumerate()
+            if not hasattr(self, "_start_time"):
+                self._start_time = time.time()
+        else:
+            self._restoreStdStreams()
         unittest.TestResult.addSkip(self, test, reason)
         self.options.output.test_skipped(test, reason)
 


### PR DESCRIPTION
Fixes #157.

This is an alternative to #158.

The PR checks in `addSkip` whether `startTest` has already been called (pre 3.12); if not, it sets up the required state usually established by `startTest`.
It keeps the pre 3.12 way to count skipped tests as run tests (to avoid complex version dependent changes for the stupid doctests).