### PR TITLE
Exit cleanly when using the test runner --version argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 6.3 (unreleased)
 ================
 
+- Exit cleanly when using the test runner ``--version`` argument.
+  (`#102 <https://github.com/zopefoundation/zope.testrunner/issues/102>`_)
+
 - Add new `--xml path` option to write `JUnit`-like XML reports.
   Code comes from `collective.xmltestreport`, but be aware that here `--xml`
   is not a boolean, but expects a path!

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -604,7 +604,6 @@ def get_options(args=None, defaults=None):
     if options.showversion:
         dist = pkg_resources.require('zope.testrunner')[0]
         print('zope.testrunner version %s' % dist.version)
-        options.fail = True
         return options
 
     if options.subunit or options.subunit_v2:

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -604,7 +604,7 @@ def get_options(args=None, defaults=None):
     if options.showversion:
         dist = pkg_resources.require('zope.testrunner')[0]
         print('zope.testrunner version %s' % dist.version)
-        return options
+        sys.exit(0)
 
     if options.subunit or options.subunit_v2:
         try:


### PR DESCRIPTION
Fixes #102 

As #102 says, it makes no sense at all to exit with an error code when asking for a version number.

I couldn't find out why that is, the code has been that way since the inception of this package.