### PR TITLE
Fix XML tests when running in distribution resp. separately.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.4 (unreleased)
 ================
 
+- Fix XML tests when running in distribution resp. separately.
+  (`#163 <https://github.com/zopefoundation/zope.testrunner/issues/163>`_)
 
 6.3 (2024-02-07)
 ================


### PR DESCRIPTION
Fixes #163

The problem was that the doctest report files have different names when running only a single test: they contain a path in the tmp directory. So I chose a unittest.

Additionally I refactored the test setup to use pathlib all over the place and to store the results in a temporary directory to prevent problems when running tests in parallel.