### PR TITLE
Implicit namespaces support

### DIFF
--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -292,11 +292,6 @@ def find_test_files_(options):
 
     for (p, package) in test_dirs(options, {}):
         for dirname, dirs, files in walk_with_symlinks(options, p):
-            if dirname != p and not contains_init_py(options, files):
-                # This is not a plausible test directory. Avoid descending
-                # further.
-                del dirs[:]
-                continue
             root2ext = {}
             dirs[:] = [d for d in dirs if identifier(d)]
             d = os.path.split(dirname)[1]

--- a/src/zope/testrunner/tests/testrunner-edge-cases.rst
+++ b/src/zope/testrunner/tests/testrunner-edge-cases.rst
@@ -419,8 +419,10 @@ Post-mortem debugging of a docfile doctest failure:
 
 Post-mortem debugging with triple verbosity
 
+    >>> sys.stdin = Input('p x\nc')
     >>> sys.argv = 'test --layer samplelayers.Layer1$ -vvv -D'.split()
-    >>> testrunner.run_internal(defaults)
+    >>> try: testrunner.run_internal(defaults)
+    ... finally: sys.stdin = real_stdin
     Running tests at level 1
     Running samplelayers.Layer1 tests:
       Set up samplelayers.Layer1 in 0.000 seconds.


### PR DESCRIPTION
Closes #160

Allow `zope.testrunner` to find tests suites for packages that follow the PEP 420 implicit namespaces.

Note that this works on test packages, like https://github.com/zopefoundation/megrok.strictrequire/pull/8

Test suite needs to be adjusted, but at least we have a reference implementation that _seems_ to be working for packages already using implicit namespaces.

To test it with `megrok.strictrequire`:

```shell
git clone git@github.com:zopefoundation/zope.testrunner
cd zope.testrunner
git checkout implicit-namespaces
git clone git@github.com:zopefoundation/megrok.strictrequire
cd megrok.strictrequire
git checkout pep440
cd ..
python3.11 -m venv venv
. venv/bin/activate
pip install -e megrok.strictrequire[test]
pip install -e .
zope-testrunner --test-path megrok.strictrequire/src
```

Most of the test failures of `zope.testrunner`'s own test suite is due to, probably, the test runner finding too much tests. I will dig into it later, but I wanted to post the PR as soon as it was minimally working ✨ 