### PR TITLE
Add missing py313-subunit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
         - ["3.10",  "py310-subunit"]
         - ["3.11",  "py311-subunit"]
         - ["3.12",  "py312-subunit"]
+        - ["3.13.0-alpha - 3.13.0",  "py313-subunit"] 
         - ["pypy-3.9", "pypy3-subunit"]
         exclude:
           - { os: ["windows", "windows-latest"], config: ["3.9",   "release-check"] }

--- a/.meta.toml
+++ b/.meta.toml
@@ -42,7 +42,7 @@ additional-config = [
 
 [tox]
 additional-envlist = [
-    "py{37,38,39,310,311,312,py3}-subunit",
+    "py{37,38,39,310,311,312,313,py3}-subunit",
     ]
 testenv-deps = [
     ]
@@ -60,5 +60,6 @@ additional-config = [
     "- [\"3.10\",  \"py310-subunit\"]",
     "- [\"3.11\",  \"py311-subunit\"]",
     "- [\"3.12\",  \"py312-subunit\"]",
+    "- [\"3.13.0-alpha - 3.13.0\",  \"py313-subunit\"]",
     "- [\"pypy-3.9\", \"pypy3-subunit\"]",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envlist =
     pypy3
     docs
     coverage
-    py{37,38,39,310,311,312,py3}-subunit
+    py{37,38,39,310,311,312,313,py3}-subunit
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Python 3.13 was tested, but not the corresponding `-subunit` test.