### PR TITLE
Hard fail on layer set up

### DIFF
--- a/src/zope/testrunner/runner.py
+++ b/src/zope/testrunner/runner.py
@@ -315,7 +315,7 @@ class Runner:
                 should_resume = True
                 break
 
-            if self.options.stop_on_error and (self.failures or self.errors):
+            if self.failures or self.errors:
                 break
 
         if should_resume:


### PR DESCRIPTION
If layer failed to setup testrunner still continue to run tests which might have side effect on other testes. Layer setup should fail hard if error happened.

`--stop-on-error` is not an option, because it also stop any failed tests which is unacceptable for CI  