### PR TITLE
Adapt to `setuptools` dropping support for `setup.py`'s `test` command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@
 - ``unittest.TestCase.subTest`` support
   (`#91 <https://github.com/zopefoundation/zope.testrunner/issues/91>`_).
 
+- remove support for ``setup.py``'s ``test`` command.
+  Support for this command has been dropped by modern
+  ``setuptools`` versions and correspondingly has been removed from
+  most ``zopefoundation`` packages; ``zope.testrunner`` now follows.
+
+- ``setup.py``'s ``ftest`` command is now only supported
+  when the used ``setuptools`` version still supports ``test``.
+
 
 6.4 (2024-02-27)
 ================

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,8 @@
 # Zope Toolkit policies as described by this documentation.
 ##############################################################################
 import os
-import sys
 
 from setuptools import setup
-from setuptools.command.test import test
 
 
 version = '6.4.1.dev0'
@@ -73,42 +71,6 @@ if __name__ == '__main__':
         '--test-path', %r, '-c',
         ])
 """
-
-
-class custom_test(test):
-    # The zope.testrunner tests MUST be run using its own testrunner. This is
-    # because its subprocess testing will call the script it was run with. We
-    # therefore create a script to run the testrunner, and call that.
-    def run(self):
-        dist = self.distribution
-
-        if dist.install_requires:
-            dist.fetch_build_eggs(dist.install_requires)
-
-        if dist.tests_require:
-            dist.fetch_build_eggs(dist.tests_require)
-
-        self.with_project_on_sys_path(self.run_tests)
-
-    def run_tests(self):
-        import tempfile
-        script = CUSTOM_TEST_TEMPLATE % (
-            sys.path, os.path.abspath(os.curdir), os.path.abspath('src'))
-        _fd, filename = tempfile.mkstemp(prefix='temprunner', text=True)
-        with open(filename, 'w') as scriptfile:
-            scriptfile.write(script)
-
-        import subprocess
-        process = subprocess.Popen([sys.executable, filename])
-        rc = process.wait()
-        try:
-            os.unlink(filename)
-        except OSError as e:
-            # This happens on Windows and I don't understand _why_.
-            sys.stderr.write("Failed to clean up temporary script %s:\n%s: %s"
-                             % (filename, e.__class__.__name__, e))
-            sys.stderr.flush()
-        sys.exit(rc)
 
 
 def read(*names):
@@ -172,7 +134,4 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    cmdclass={
-        'test': custom_test,
-    },
 )

--- a/src/zope/testrunner/eggsupport.py
+++ b/src/zope/testrunner/eggsupport.py
@@ -1,8 +1,13 @@
 """ Add unit and functional testing support to setuptools-driven eggs.
 """
 
-from setuptools.command.test import ScanningLoader
-from setuptools.command.test import test as BaseCommand
+try:
+    from setuptools.command.test import ScanningLoader
+    from setuptools.command.test import test as BaseCommand
+except ImportError:
+    # a modern ``setuptools`` no longer supporting the ``test`` command
+    ScanningLoader = object
+    from setuptools import Command as BaseCommand
 
 
 def skipLayers(suite, _result=None):
@@ -109,6 +114,13 @@ class ftest(BaseCommand):
         pass  # suppress normal handling
 
     def run(self):
+        if ScanningLoader is object:
+            # modern ``setuptools`` no longer supporting ``test``
+            from sys import exit
+            exit("You are using a modern `setuptools` version "
+                 "which no longer supports the ``test`` command. "
+                 "`zope.testrunner`'s `ftest` command depends on this "
+                 "and therefore cannot be used.")
         from zope.testrunner import run
         args = ['IGNORE_ME']
 

--- a/src/zope/testrunner/tests/test_doctest.py
+++ b/src/zope/testrunner/tests/test_doctest.py
@@ -230,7 +230,6 @@ def test_suite():
             'testrunner-repeat.rst',
             'testrunner-knit.rst',
             'testrunner-shuffle.rst',
-            'testrunner-eggsupport.rst',
             'testrunner-stops-when-stop-on-error.rst',
             'testrunner-new-threads.rst',
             'testrunner-subtest.rst',
@@ -243,6 +242,19 @@ def test_suite():
         doctest.DocTestSuite('zope.testrunner.options'),
         doctest.DocTestSuite('zope.testrunner.find'),
     ]
+
+    try:
+        from setuptools.command.test import ScanningLoader  # noqa: F401
+    except ImportError:
+        # modern ``setuptools`` without ``test`` support
+        pass
+    else:
+        suites.append(
+            doctest.DocFileSuite(
+                'testrunner-eggsupport.rst',
+                setUp=setUp, tearDown=tearDown,
+                optionflags=optionflags,
+                checker=checker))
 
     # PyPy uses a different garbage collector
     if hasattr(gc, 'get_threshold'):


### PR DESCRIPTION
Modern `setuptools`  versions (72+) have dropped support for `setup.py`'s `test` command. Many `zopefoundation` packages have therefore removed this command from their `setup.py`. This PR does the same for `zope.testrunner`.

In addition, `zope.testrunner`'s `setup.py`'s `ftest` command depends on infrastructure for `setuptools`'s `test` command. This PR still supports `ftest` for `setuptools` versions still supporting `test`. For other versions, the command lets the process exit with a descriptive message. An alternative would have been to completely drop support for `ftest`.