### PR TITLE
Modernize setuptools usage & exclude tests from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
-    packages=find_namespace_packages(where='src'),
+    packages=find_namespace_packages(where='src', exclude=['zope.testrunner.tests*']),
     package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -124,6 +124,6 @@ setup(
         'distutils.commands': [
             'ftest = zope.testrunner.eggsupport:ftest'],
     },
-    include_package_data=True,
+    include_package_data=False,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,6 @@ else:
 import os
 os.chdir(%r)
 
-# The following unused imports are dark magic that makes the tests pass on
-# Python 3.5 on Travis CI.  I do not understand why.
-import zope.exceptions.exceptionformatter
-import zope.testing
-
 import zope.testrunner
 if __name__ == '__main__':
     zope.testrunner.run([

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 ##############################################################################
 import os
 
-from setuptools import find_namespace_packages
+from setuptools import find_packages
 from setuptools import setup
 
 
@@ -91,7 +91,7 @@ setup(
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
-    packages=find_namespace_packages(where='src', exclude=['zope.testrunner.tests*']),
+    packages=find_packages(where='src', exclude=['zope.testrunner.tests*']),
     package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -114,6 +114,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",
     ],
+    namespace_packages=['zope'],
     python_requires='>=3.7',
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 ##############################################################################
 import os
 
+from setuptools import find_namespace_packages
 from setuptools import setup
 
 
@@ -90,10 +91,7 @@ setup(
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
-    packages=[
-        "zope",
-        "zope.testrunner",
-    ],
+    packages=find_namespace_packages(where='src'),
     package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -116,7 +114,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",
     ],
-    namespace_packages=['zope'],
     python_requires='>=3.7',
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRE,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Hey :wave:

I maintain the [Arch Linux package for zope.testrunner](https://archlinux.org/packages/extra/any/python-zope-testrunner/). This is a set of packaging changes that, in my view, are appropriate - the primary one being to stop including tests in the distributed wheel.

As the wheel's primary purpose is to be installed in a virtualenv or on a system, the tests for testrunner itself are unnecessary to include. Including them also makes distro-tooling such as Arch Linux's namcap produce noisy
warnings regarding missing dependencies.

Before these changes:

```sh
$ rm -rf build dist/ src/zope.testrunner.egg-info/; python -m build --wheel
...
Successfully built zope.testrunner-6.6.dev0-py3-none-any.whl
$ find build/lib/zope/testrunner/ -iname tests
build/lib/zope/testrunner/tests
```

After:

```sh
$ rm -rf build dist/ src/zope.testrunner.egg-info/; python -m build --wheel
...
Successfully built zope.testrunner-6.6.dev0-py3-none-any.whl
$ find build/lib/zope/testrunner/ -iname tests
```

The tests are still included in the sdist as per the MANIFEST.in file:

```sh
$ rm -rf build dist/ src/zope.testrunner.egg-info/; python -m build --sdist
...
Successfully built zope_testrunner-6.6.dev0.tar.gz
$ tar -xf dist/zope_testrunner-6.6.dev0.tar.gz
$ find zope_testrunner-6.6.dev0/ -iname tests
zope_testrunner-6.6.dev0/src/zope/testrunner/tests
```
