### PR TITLE
exclude `eggsupport.py` from `coverage`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = eggsupport.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = eggsupport.py

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
     coverage
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run -m zope.testrunner --test-path=src {posargs:-vc}
+    coverage run --omit eggsupport.py -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html --ignore-errors
     coverage report --ignore-errors --show-missing --fail-under=84
 

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
     coverage
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run --omit eggsupport.py -m zope.testrunner --test-path=src {posargs:-vc}
+    coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html --ignore-errors
     coverage report --ignore-errors --show-missing --fail-under=84
 


### PR DESCRIPTION
This PR excludes `eggsupport.py` from the `coverage` analysis:
the `eggsupport.py` functionality is available only for older `setuptools` versions and the GH testrunnter uses a newer one. As a consequence, `eggsupport.py` is no longer covered by the test suite and the `coverage` check fails.