### PR TITLE
make signatures in `tb_format` compatible with Python 3.12+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 6.7 (unreleased)
 ================
 
-- Nothing changed yet.
+- Make signatures in ``tb_format`` Python 3.12+ compatible
+  (`#186 <https://github.com/zopefoundation/zope.testrunner/issues/186>`_)
 
 
 6.6 (2024-10-16)

--- a/src/zope/testrunner/tb_format.py
+++ b/src/zope/testrunner/tb_format.py
@@ -22,6 +22,13 @@ import zope.exceptions.exceptionformatter
 import zope.testrunner.feature
 
 
+try:
+    from traceback import _sentinel
+except ImportError:
+    # before 3.12
+    _sentinel = False
+
+
 def _iter_chain(exc, custom_tb=None, seen=None):
     if seen is None:
         seen = set()
@@ -47,9 +54,9 @@ def _parse_value_tb(exc, value, tb):
     # Taken straight from the traceback module code on Python 3.10, which
     # introduced the ability to call print_exception with an exception
     # instance as first parameter
-    if (value is None) != (tb is None):
+    if (value is _sentinel) != (tb is _sentinel):
         raise ValueError("Both or neither of value and tb must be given")
-    if value is tb is None:
+    if value is tb is _sentinel:
         if exc is not None:
             return exc, exc.__traceback__
         else:
@@ -57,7 +64,8 @@ def _parse_value_tb(exc, value, tb):
     return value, tb
 
 
-def format_exception(t, v, tb, limit=None, chain=None):
+def format_exception(t, value=_sentinel, tb=_sentinel, limit=None, chain=None):
+    v, tb = _parse_value_tb(t, value, tb)
     if chain:
         values = _iter_chain(v, tb)
     else:
@@ -70,8 +78,9 @@ def format_exception(t, v, tb, limit=None, chain=None):
         return fmt.formatException(t, v, tb)
 
 
-def print_exception(t, v=None, tb=None, limit=None, file=None, chain=None):
-    v, tb = _parse_value_tb(t, v, tb)
+def print_exception(t, value=_sentinel, tb=_sentinel,
+                    limit=None, file=None, chain=None):
+    v, tb = _parse_value_tb(t, value, tb)
     if chain:
         values = _iter_chain(v, tb)
     else:

--- a/src/zope/testrunner/tb_format.py
+++ b/src/zope/testrunner/tb_format.py
@@ -25,8 +25,8 @@ import zope.testrunner.feature
 try:
     from traceback import _sentinel
 except ImportError:
-    # before 3.12
-    _sentinel = False
+    # before 3.10
+    _sentinel = None
 
 
 def _iter_chain(exc, custom_tb=None, seen=None):


### PR DESCRIPTION
Fixes #186.

`zope.testrunner` overrides the `traceback` funktions `print_exception` and `format_exception` for two reasons:
1. Python's functions have `True` as default for the parameter `chain`  causing a nested traceback display
2. Python's functions mark some traceback lines with `^^^^^^`.
Both risk to let existing doctests fail.

Python 3.12 has changed the signatures of its functions above. This PR modifies the signature of its overriding functions to be compatible with all supported Python versions.