### PR TITLE
Add option `--only-level=level` to run tests only at the specified level.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 6.7 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add option ``--only-level=level`` to run tests only at the specified level.
+  (`#188 <https://github.com/zopefoundation/zope.testrunner/issues/188>`_)
 
 
 6.6.1 (2024-12-13)

--- a/src/zope/testrunner/filter.py
+++ b/src/zope/testrunner/filter.py
@@ -70,8 +70,14 @@ class Filter(zope.testrunner.feature.Feature):
             if self.runner.options.all:
                 msg = "Running tests at all levels"
             else:
-                msg = (
-                    "Running tests at level %d" % self.runner.options.at_level)
+                if self.runner.options.only_level is None:
+                    msg = (
+                        "Running tests at level %d" %
+                        self.runner.options.at_level)
+                else:
+                    msg = (
+                        "Running tests only at level %d" %
+                        self.runner.options.only_level)
             self.runner.options.output.info(msg)
 
     def report(self):

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -471,9 +471,14 @@ def tests_from_suite(suite, options, dlevel=1,
                 duplicated_test_ids.add(suite_id)
             else:
                 seen_test_ids.add(suite_id)
-        if options.at_level <= 0 or level <= options.at_level:
-            if accept is None or accept(str(suite)):
-                yield (suite, layer)
+        if options.only_level is None:
+            if options.at_level <= 0 or level <= options.at_level:
+                if accept is None or accept(str(suite)):
+                    yield (suite, layer)
+        else:
+            if level == options.only_level:
+                if accept is None or accept(str(suite)):
+                    yield (suite, layer)
 
 
 _layer_name_cache = {}

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -141,6 +141,15 @@ searching.add_argument(
     help="Run tests at all levels.")
 
 searching.add_argument(
+    '--only-level', type=int, dest='only_level',
+    default=None,
+    help="""\
+Run only the tests at the given level. Tests on other levels are not run.
+Default is None, which means the level is not restricted by this option.
+If this option is used it overrides `--at-level` and `--all` options.
+""")
+
+searching.add_argument(
     '--list-tests', action="store_true", dest='list_tests',
     default=False,
     help="List all tests that matched your filters.  Do not run any tests.")

--- a/src/zope/testrunner/tests/test_find.py
+++ b/src/zope/testrunner/tests/test_find.py
@@ -25,6 +25,7 @@ class UniquenessOptions:
 
     keepbytecode = True
     at_level = 99
+    only_level = None
     test = []
     module = []
     require_unique_ids = True

--- a/src/zope/testrunner/tests/testrunner-test-selection.rst
+++ b/src/zope/testrunner/tests/testrunner-test-selection.rst
@@ -524,6 +524,22 @@ additional tests:
       Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
     False
 
+We get run 38 tests.  We can specify to run only the level 2 tests using
+``--only-level=2``. So we run less tests:
+
+    >>> sys.argv = 'test -u  -vv --only-level=2 -t test_y1 -t test_y0'.split()
+    >>> testrunner.run_internal(defaults)
+    Running tests only at level 2
+    Running zope.testrunner.layer.UnitTests tests:
+      Set up zope.testrunner.layer.UnitTests in N.NNN seconds.
+      Running:
+     test_y0 (sampletestsf.TestA2...)
+     test_y1 (sample1.sample11.sampletests.TestB2...)
+      Ran 2 tests with 0 failures, 0 errors and 0 skipped in N.NNN seconds.
+    Tearing down left over layers:
+      Tear down zope.testrunner.layer.UnitTests in N.NNN seconds.
+    False
+
 
 We can use the --all option to run tests at all levels:
 


### PR DESCRIPTION
Fixes #188.