### PR TITLE
Add ``--auto-path`` option.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 7.4 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add ``--auto-path`` option.
+  This automatically adds the path of all packages from the ``--package`` option to the test paths.
 
 
 7.3 (2025-05-15)

--- a/src/zope/testrunner/find.py
+++ b/src/zope/testrunner/find.py
@@ -347,8 +347,8 @@ def strip_py_ext(options, path):
 
 def test_dirs(options, seen):
     if options.package:
-        for p in options.package:
-            p = import_name(p)
+        for package_name in options.package:
+            p = import_name(package_name)
             for p in p.__path__:
                 p = os.path.abspath(p)
                 if p in seen:
@@ -358,6 +358,13 @@ def test_dirs(options, seen):
                         seen[p] = 1
                         yield p, package
                         break
+                else:
+                    if options.auto_path:
+                        seen[p] = 1
+                        result = p + os.path.sep, package_name
+                        options.prefix.append(result)
+                        yield result
+
     else:
         yield from options.test_path
 

--- a/src/zope/testrunner/options.py
+++ b/src/zope/testrunner/options.py
@@ -456,6 +456,12 @@ although it can be overridden by users.  Only tests found in the path
 will be run.
 """)
 
+searching.add_argument(
+    '--auto-path', action="store_true", dest='auto_path',
+    help="""\
+Automatically add path of --package to the test paths.
+""")
+
 setup.add_argument(
     '--tests-pattern', action="store", dest='tests_pattern',
     default=_regex_search('^tests$'),


### PR DESCRIPTION
This automatically adds the path of all packages from the ``--package`` option to the test paths.

Use case: install all Plone packages with pip, some with an editable install, install `zope.testrunner`, and then call for example `zope-testrunner --auto-path -s plone.memoize -s plone.base` without having to set the `--test-path` for each package.

Otherwise this gets tricky when some packages are in site-packages and some editable in a `src` directory, and for editable installs their code may or may not be within a `src` sub directory:

```
zope-testrunner --test-path=src/plone.base/src --test-path=.venv/lib/python3.13/site-packages -s plone.base -s plone.memoize
```

With Buildout you can easily do it like this:

```
[test]
recipe = zc.recipe.testrunner
eggs = ${buildout:test-eggs}
```

With the `--auto-path` option you say: "I don't care where it exactly is, just find the tests of that package and run them."  You can still pass other `--test-path` options if you need.

I am not sure how to add tests for this feature.