### PR TITLE
Release 7.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  zope.testrunner Changelog
 ===========================
 
+7.5 (unreleased)
+================
+
+- Nothing changed yet.
+
+
 7.4 (2025-05-28)
 ================
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 from setuptools import setup
 
 
-version = '7.4'
+version = '7.5.dev0'
 
 INSTALL_REQUIRES = [
     'setuptools',


### PR DESCRIPTION
I have released [7.4 on PyPI](https://pypi.org/project/zope.testrunner/7.4/), but I cannot push directly to master.