### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 8.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 7.4 (2025-05-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  zope.testrunner Changelog
 ===========================
 
-7.5 (unreleased)
+8.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,6 @@ setup(
     long_description=long_description,
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
-    packages=[
-        "zope",
-        "zope.testrunner",
-    ],
-    package_dir={'': 'src'},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -92,7 +87,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",
     ],
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 from setuptools import setup
 
 
-version = '7.5.dev0'
+version = '8.0.dev0'
 
 INSTALL_REQUIRES = [
     'setuptools',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
