### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 8.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Remove run-time dependency on ``setuptools``.
 
 
 8.0 (2025-09-12)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ from setuptools import setup
 version = '8.1.dev0'
 
 INSTALL_REQUIRES = [
-    'setuptools',
     'zope.exceptions',
     'zope.interface',
 ]

--- a/src/zope/testrunner/__init__.py
+++ b/src/zope/testrunner/__init__.py
@@ -17,8 +17,6 @@
 import os
 import sys
 
-import pkg_resources  # noqa: F401 unused import, see GitHub issue #194
-
 
 def run(defaults=None, args=None, script_parts=None, cwd=None, warnings=None):
     """Main runner function which can be and is being used from main programs.


### PR DESCRIPTION
It was needed for `pkg_resources`-style namespace packages, but that's no longer a problem here.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [N/A] If needed, I added new tests for my changes.
- [N/A] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.