### PR TITLE
Skip _SubTest objects

### DIFF
--- a/src/zope/testrunner/tests/test_xml_output.py
+++ b/src/zope/testrunner/tests/test_xml_output.py
@@ -133,7 +133,8 @@ class TextXMLOutputWithErrors(Base):
         # Python 3.15+ includes an additional unittest.case._SubTest.xml file
         # containing subtest information
         expected_count = 107 if sys.version_info >= (3, 15) else 106
-        self.assertEqual(len([x for x in self.reports_folder.iterdir()]), expected_count)
+        self.assertEqual(
+            len([x for x in self.reports_folder.iterdir()]), expected_count)
 
     def test_xml_report_with_errors_details(self):
         sys.argv = 'test --tests-pattern ^sampletests(f|_e|_f)?$ '.split()

--- a/src/zope/testrunner/tests/test_xml_output.py
+++ b/src/zope/testrunner/tests/test_xml_output.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from zope import testrunner
 
 
+PY314_OR_OLDER = sys.version_info < (3, 15)
+
 class Base(unittest.TestCase):
 
     def tearDown(self):
@@ -130,9 +132,9 @@ class TextXMLOutputWithErrors(Base):
         self._run_tests()
 
         self.assertTrue(self.reports_folder.exists())
-        # Python 3.15+ includes an additional unittest.case._SubTest.xml file
+        # Python < 3.15 does not include a unittest.case._SubTest.xml file
         # containing subtest information
-        expected_count = 107 if sys.version_info >= (3, 15) else 106
+        expected_count = 106 if PY314_OR_OLDER else 107
         self.assertEqual(
             len([x for x in self.reports_folder.iterdir()]), expected_count)
 

--- a/src/zope/testrunner/tests/test_xml_output.py
+++ b/src/zope/testrunner/tests/test_xml_output.py
@@ -26,6 +26,7 @@ from zope import testrunner
 
 PY314_OR_OLDER = sys.version_info < (3, 15)
 
+
 class Base(unittest.TestCase):
 
     def tearDown(self):

--- a/src/zope/testrunner/tests/test_xml_output.py
+++ b/src/zope/testrunner/tests/test_xml_output.py
@@ -130,7 +130,10 @@ class TextXMLOutputWithErrors(Base):
         self._run_tests()
 
         self.assertTrue(self.reports_folder.exists())
-        self.assertEqual(len([x for x in self.reports_folder.iterdir()]), 106)
+        # Python 3.15+ includes an additional unittest.case._SubTest.xml file
+        # containing subtest information
+        expected_count = 107 if sys.version_info >= (3, 15) else 106
+        self.assertEqual(len([x for x in self.reports_folder.iterdir()]), expected_count)
 
     def test_xml_report_with_errors_details(self):
         sys.argv = 'test --tests-pattern ^sampletests(f|_e|_f)?$ '.split()


### PR DESCRIPTION
We are building Python packages in Fedora Linux with Python 3.15 already and one test failed with the following error:

```
Failure in test test_xml_report_with_errors (zope.testrunner.tests.test_xml_output.TextXMLOutputWithErrors.test_xml_report_with_errors)
Traceback (most recent call last):
  File "/usr/lib64/python3.15/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib64/python3.15/unittest/case.py", line 667, in run
    self._callTestMethod(testMethod)
  File "/usr/lib64/python3.15/unittest/case.py", line 613, in _callTestMethod
    result = method()
  File "/builddir/build/BUILD/python-zope-testrunner-8.2-build/BUILDROOT/usr/lib/python3.15/site-packages/zope/testrunner/tests/test_xml_output.py", line 133, in test_xml_report_with_errors
    self.assertEqual(len([x for x in self.reports_folder.iterdir()]), 106)
  File "/usr/lib64/python3.15/unittest/case.py", line 925, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib64/python3.15/unittest/case.py", line 918, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 107 != 106
```

Excluding _SubTest objects makes the test pass because the number of files matches the expected one. I'm not sure why this behavior is different in CPython 3.15 as I wasn't able to find the respective change there.